### PR TITLE
Always return an empty array as a menu to fleximenu

### DIFF
--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_lrRadioMenu.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_lrRadioMenu.sqf
@@ -1,4 +1,5 @@
-private ["_menuDef", "_positions", "_active_radio", "_submenu", "_command", "_pos"];
+private ["_menuDef", "_positions", "_active_radio", "_submenu", "_command", "_pos", "_menu"];
+_menu = [];
 if (count (call TFAR_fnc_lrRadiosList) > 1) then
 {
 	_menuDef = ["main", localize "STR_select_lr_radio", "buttonList", "", false];
@@ -31,11 +32,10 @@ if (count (call TFAR_fnc_lrRadiosList) > 1) then
 		_menuDef,
 		_positions	
 	];
-	_menu
 } else {
 	if (call TFAR_fnc_haveLRRadio) then {
 		TF_lr_dialog_radio = call TFAR_fnc_activeLrRadio;
 		call TFAR_fnc_onLrDialogOpen;
 	};
-	nil
 };
+_menu

--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_swRadioMenu.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_swRadioMenu.sqf
@@ -1,4 +1,5 @@
-private ["_menuDef", "_positions", "_active_radio", "_submenu", "_command"];
+private ["_menuDef", "_positions", "_active_radio", "_submenu", "_command", "_menu"];
+_menu = [];
 if ((count (call TFAR_fnc_radiosList) > 1) or {(count (call TFAR_fnc_radiosList) == 1) and !(call TFAR_fnc_haveSWRadio) }) then
 {
 	_menuDef = ["main", localize "STR_select_radio", "buttonList", "", false];
@@ -29,11 +30,10 @@ if ((count (call TFAR_fnc_radiosList) > 1) or {(count (call TFAR_fnc_radiosList)
 		_menuDef,
 		_positions	
 	];
-	_menu
 } else {
 	if (call TFAR_fnc_haveSWRadio) then {
 		TF_sw_dialog_radio = call TFAR_fnc_activeSwRadio;
 		call TFAR_fnc_onSwDialogOpen;
 	};
-	nil
 };
+_menu


### PR DESCRIPTION
Reduces the RPT errors down to https://github.com/michail-nikolaev/task-force-arma-3-radio/issues/365
