### PR TITLE
Implemented changes suggested here, 

### DIFF
--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_getLrSettings.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_getLrSettings.sqf
@@ -25,7 +25,7 @@ _radio_qualifier = _this select 1;
 _value = _radio_object getVariable _radio_qualifier;
 if (isNil "_value") then {
 	if (!(TF_use_saved_lr_setting) or (isNil "TF_saved_active_lr_settings")) then {
-		if (([side player, 0] call TFAR_fnc_getSideRadio) == (typeof _radio_object)) then
+		if ((call TFAR_fnc_getDefaultRadioClasses select 0) == (typeof _radio_object)) then
 		{
 			_value = (group player) getVariable "tf_lr_frequency";
 		};
@@ -42,15 +42,22 @@ if (isNil "_value") then {
 };
 _rc = _value select TF_CODE_OFFSET;
 if (isNil "_rc") then {
-	if (getText (ConfigFile >>  "CfgVehicles" >> (typeof _radio_object) >> "tf_encryptionCode") != "") then {
-		if (([side player, 0] call TFAR_fnc_getSideRadio) == (typeof _radio_object)) then {
+	private ["_code", "_hasDefaultEncryption"];
+	_code = getText (ConfigFile >>  "CfgVehicles" >> (typeof _radio_object) >> "tf_encryptionCode");
+	_hasDefaultEncryption = (_code == "tf_west_radio_code") or {_code == "tf_east_radio_code"} or {_code == "tf_guer_radio_code"};
+	if (_hasDefaultEncryption) then {
+		if ((call TFAR_fnc_getDefaultRadioClasses select 0) == (typeof _radio_object)) then {
 			_rc = missionNamespace getVariable format ["tf_%1_radio_code",(side player)];
 		}else{
 			_rc = missionNamespace getVariable [[_radio_object, "tf_encryptionCode"] call TFAR_fnc_getLrRadioProperty, ""];
 		};
 	} else {
 		_rc = "";
+		if (_code != "") then {
+			_rc = missionNamespace getVariable [[_radio_object, "tf_encryptionCode"] call TFAR_fnc_getLrRadioProperty, ""];
+		};
 	};
+	
 	_value set [TF_CODE_OFFSET, _rc];
 	[_radio_object, _radio_qualifier, + _value] call TFAR_fnc_setLrSettings;
 };

--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_getSwSettings.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_getSwSettings.sqf
@@ -23,10 +23,10 @@ _variableName = format["%1_settings", _this];
 _value = missionNamespace getVariable _variableName;
 if (isNil "_value") then {
 	if (!(TF_use_saved_sw_setting) or (isNil "TF_saved_active_sw_settings")) then {
-		private "_parent";
+		private ["_parent", "_defaultRadios"];
+		_defaultRadios = call TFAR_fnc_getDefaultRadioClasses;
 		_parent = getText (ConfigFile >> "CfgWeapons" >> _this >> "tf_parent");
-		if (([side player, 1] call TFAR_fnc_getSideRadio) == _parent or {([side player, 2] call TFAR_fnc_getSideRadio) == _parent}) then
-		{
+		if ((_defaultRadios select 1) == _parent or {(_defaultRadios select 2) == _parent}) then {
 			_value = (group player) getVariable "tf_sw_frequency";
 		};
 		if (isNil "_value") then {
@@ -43,16 +43,23 @@ if (isNil "_value") then {
 _rc = _value select TF_CODE_OFFSET;
 if (isNil "_rc") then
 {
-	private "_parent";
-	if (getText (ConfigFile >>  "CfgWeapons" >> _this >> "tf_encryptionCode") != "") then {
+	private ["_parent", "_code", "_hasDefaultEncryption"];
+	_code = getText (ConfigFile >>  "CfgWeapons" >> _this >> "tf_encryptionCode");
+	_hasDefaultEncryption = (_code == "tf_west_radio_code") or {_code == "tf_east_radio_code"} or {_code == "tf_guer_radio_code"};
+	if (_hasDefaultEncryption) then {
 		_parent = getText (ConfigFile >> "CfgWeapons" >> _this >> "tf_parent");
-		if (([side player, 1] call TFAR_fnc_getSideRadio) == _parent or {([side player, 2] call TFAR_fnc_getSideRadio) == _parent}) then {
+		private "_default";
+		_default = call TFAR_fnc_getDefaultRadioClasses;
+		if ((_default select 1) == _parent or {(_default select 2) == _parent}) then {
 			_rc = missionNamespace getVariable format ["tf_%1_radio_code",(side player)];
 		}else{
-			_rc = missionNamespace getVariable [getText(configFile >> "CfgWeapons" >> _this >> "tf_encryptionCode"), ""];
+			_rc = missionNamespace getVariable [_code, ""];
 		};
 	} else {
 		_rc = "";
+		if (_code != "") then {
+			_rc = missionNamespace getVariable [_code, ""];
+		};
 	};
 	_value set [TF_CODE_OFFSET, _rc];
 	[_this, + _value] call TFAR_fnc_setSwSettings;

--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_initialiseBaseModule.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_initialiseBaseModule.sqf
@@ -46,6 +46,9 @@ if (_activated) then {
 	_radio = _logic getVariable "Radio";
 	_currentSide = "North";
 	
+	tf_same_sw_frequencies_for_side = true;
+	tf_same_lr_frequencies_for_side = true;
+	
 	{
 		if ((str _currentSide) != (str side _x)) then {
 			_currentSide = side _x;

--- a/debug/TaskForceRadioDebug.Altis/task_force_radio/functions/fn_getLrSettings.sqf
+++ b/debug/TaskForceRadioDebug.Altis/task_force_radio/functions/fn_getLrSettings.sqf
@@ -25,7 +25,7 @@ _radio_qualifier = _this select 1;
 _value = _radio_object getVariable _radio_qualifier;
 if (isNil "_value") then {
 	if (!(TF_use_saved_lr_setting) or (isNil "TF_saved_active_lr_settings")) then {
-		if (([side player, 0] call TFAR_fnc_getSideRadio) == (typeof _radio_object)) then
+		if ((call TFAR_fnc_getDefaultRadioClasses select 0) == (typeof _radio_object)) then
 		{
 			_value = (group player) getVariable "tf_lr_frequency";
 		};
@@ -42,15 +42,22 @@ if (isNil "_value") then {
 };
 _rc = _value select TF_CODE_OFFSET;
 if (isNil "_rc") then {
-	if (getText (ConfigFile >>  "CfgVehicles" >> (typeof _radio_object) >> "tf_encryptionCode") != "") then {
-		if (([side player, 0] call TFAR_fnc_getSideRadio) == (typeof _radio_object)) then {
+	private ["_code", "_hasDefaultEncryption"];
+	_code = getText (ConfigFile >>  "CfgVehicles" >> (typeof _radio_object) >> "tf_encryptionCode");
+	_hasDefaultEncryption = (_code == "tf_west_radio_code") or {_code == "tf_east_radio_code"} or {_code == "tf_guer_radio_code"};
+	if (_hasDefaultEncryption) then {
+		if ((call TFAR_fnc_getDefaultRadioClasses select 0) == (typeof _radio_object)) then {
 			_rc = missionNamespace getVariable format ["tf_%1_radio_code",(side player)];
 		}else{
 			_rc = missionNamespace getVariable [[_radio_object, "tf_encryptionCode"] call TFAR_fnc_getLrRadioProperty, ""];
 		};
 	} else {
 		_rc = "";
+		if (_code != "") then {
+			_rc = missionNamespace getVariable [[_radio_object, "tf_encryptionCode"] call TFAR_fnc_getLrRadioProperty, ""];
+		};
 	};
+	
 	_value set [TF_CODE_OFFSET, _rc];
 	[_radio_object, _radio_qualifier, + _value] call TFAR_fnc_setLrSettings;
 };

--- a/debug/TaskForceRadioDebug.Altis/task_force_radio/functions/fn_getSwSettings.sqf
+++ b/debug/TaskForceRadioDebug.Altis/task_force_radio/functions/fn_getSwSettings.sqf
@@ -23,10 +23,10 @@ _variableName = format["%1_settings", _this];
 _value = missionNamespace getVariable _variableName;
 if (isNil "_value") then {
 	if (!(TF_use_saved_sw_setting) or (isNil "TF_saved_active_sw_settings")) then {
-		private "_parent";
+		private ["_parent", "_defaultRadios"];
+		_defaultRadios = call TFAR_fnc_getDefaultRadioClasses;
 		_parent = getText (ConfigFile >> "CfgWeapons" >> _this >> "tf_parent");
-		if (([side player, 1] call TFAR_fnc_getSideRadio) == _parent or {([side player, 2] call TFAR_fnc_getSideRadio) == _parent}) then
-		{
+		if ((_defaultRadios select 1) == _parent or {(_defaultRadios select 2) == _parent}) then {
 			_value = (group player) getVariable "tf_sw_frequency";
 		};
 		if (isNil "_value") then {
@@ -43,16 +43,23 @@ if (isNil "_value") then {
 _rc = _value select TF_CODE_OFFSET;
 if (isNil "_rc") then
 {
-	private "_parent";
-	if (getText (ConfigFile >>  "CfgWeapons" >> _this >> "tf_encryptionCode") != "") then {
+	private ["_parent", "_code", "_hasDefaultEncryption"];
+	_code = getText (ConfigFile >>  "CfgWeapons" >> _this >> "tf_encryptionCode");
+	_hasDefaultEncryption = (_code == "tf_west_radio_code") or {_code == "tf_east_radio_code"} or {_code == "tf_guer_radio_code"};
+	if (_hasDefaultEncryption) then {
 		_parent = getText (ConfigFile >> "CfgWeapons" >> _this >> "tf_parent");
-		if (([side player, 1] call TFAR_fnc_getSideRadio) == _parent or {([side player, 2] call TFAR_fnc_getSideRadio) == _parent}) then {
+		private "_default";
+		_default = call TFAR_fnc_getDefaultRadioClasses;
+		if ((_default select 1) == _parent or {(_default select 2) == _parent}) then {
 			_rc = missionNamespace getVariable format ["tf_%1_radio_code",(side player)];
 		}else{
-			_rc = missionNamespace getVariable [getText(configFile >> "CfgWeapons" >> _this >> "tf_encryptionCode"), ""];
+			_rc = missionNamespace getVariable [_code, ""];
 		};
 	} else {
 		_rc = "";
+		if (_code != "") then {
+			_rc = missionNamespace getVariable [_code, ""];
+		};
 	};
 	_value set [TF_CODE_OFFSET, _rc];
 	[_this, + _value] call TFAR_fnc_setSwSettings;

--- a/debug/TaskForceRadioDebug.Altis/task_force_radio/functions/fn_initialiseBaseModule.sqf
+++ b/debug/TaskForceRadioDebug.Altis/task_force_radio/functions/fn_initialiseBaseModule.sqf
@@ -46,6 +46,9 @@ if (_activated) then {
 	_radio = _logic getVariable "Radio";
 	_currentSide = "North";
 	
+	tf_same_sw_frequencies_for_side = true;
+	tf_same_lr_frequencies_for_side = true;
+	
 	{
 		if ((str _currentSide) != (str side _x)) then {
 			_currentSide = side _x;


### PR DESCRIPTION
https://github.com/michail-nikolaev/task-force-arma-3-radio/issues/532 also added in a check for if the tf_encryptionCode is set to nothing for a radio in config to avoid potential errors further down the line when non-encrypted radios are required.
