### PR TITLE
Fixed server side code breaking when passed incorrect radio request list...

### DIFF
--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_ServerInit.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_ServerInit.sqf
@@ -48,32 +48,37 @@ while {true} do {
 				(owner (_x)) publicVariableClient (_variableName);
 				_responseVariableName = "radio_response_" + (getPlayerUID _x) + str (_x call BIS_fnc_objectSide);
 				_response = [];
-				{
-					private ["_radio", "_count"];
-					_radio = _x;
-					if !(_radio call TFAR_fnc_isPrototypeRadio) then
+				if (typename _radio_request == "ARRAY") then {
 					{
-						_radio = inheritsFrom (configFile >> "CfgWeapons" >> _radio);
-					};
-					_count = -1;
-					{
-						if ((_x select 0) == _radio) exitWith
+						private ["_radio", "_count"];
+						_radio = _x;
+						if !(_radio call TFAR_fnc_isPrototypeRadio) then
 						{
-							_x set [1, (_x select 1) + 1];
-							if ((_x select 1) > MAX_RADIO_COUNT) then
-							{
-								_x set [1, 1];
-							};
-							_count = (_x select 1);
+							_radio = inheritsFrom (configFile >> "CfgWeapons" >> _radio);
 						};
-					} count TF_Radio_Count;
-					if (_count == -1) then
-					{
-						TF_Radio_Count set [(count TF_Radio_Count), [_x,1]];
-						_count = 1;
-					};
-					_response set [(count _response), format["%1_%2", _radio, _count]];
-				} count _radio_request;
+						_count = -1;
+						{
+							if ((_x select 0) == _radio) exitWith
+							{
+								_x set [1, (_x select 1) + 1];
+								if ((_x select 1) > MAX_RADIO_COUNT) then
+								{
+									_x set [1, 1];
+								};
+								_count = (_x select 1);
+							};
+						} count TF_Radio_Count;
+						if (_count == -1) then
+						{
+							TF_Radio_Count set [(count TF_Radio_Count), [_x,1]];
+							_count = 1;
+						};
+						_response set [(count _response), format["%1_%2", _radio, _count]];
+					} count _radio_request;
+				} else {
+					_response = "ERROR:47";
+					diag_log format ["TFAR - ERROR:47 - Request Content: %1; Requested By: %2", _radio_reqest, _x];
+				};
 				missionNamespace setVariable [_responseVariableName, _response];
 				(owner (_x)) publicVariableClient (_responseVariableName);
 			};

--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_requestRadios.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_requestRadios.sqf
@@ -35,14 +35,18 @@ if (time - TF_last_request_time > 3) then {
 		publicVariableServer _variableName;
 		titleText [localize ("STR_wait_radio"), "PLAIN"];
 		waitUntil {!(isNil _responseVariableName)};
-		_response = missionNamespace getVariable _responseVariableName;	
-		{
-			player addItem _x;
-		} count _response;
-		if ((count _response > 0) and (TF_first_radio_request)) then 
-		{
-			TF_first_radio_request = false;
-			player assignItem (_response select 0);
+		_response = missionNamespace getVariable _responseVariableName;
+		if (typename _response == "ARRAY") then {
+			{
+				player addItem _x;
+			} count _response;
+			if ((count _response > 0) and (TF_first_radio_request)) then 
+			{
+				TF_first_radio_request = false;
+				player assignItem (_response select 0);
+			};
+		}else{
+			hintC _response;
 		};
 		titleText ["", "PLAIN"];
 	};


### PR DESCRIPTION
... (not an array)

Passes back ERROR:47 to client if incorrect radio request type is sent to client and written to RPT file.

Fixes https://github.com/michail-nikolaev/task-force-arma-3-radio/issues/559
