### PR TITLE
Whether to give rifleman radios instead of personal radios can be set in...

### DIFF
--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_ClientInit.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_ClientInit.sqf
@@ -63,10 +63,6 @@ if (isNil "TF_defaultGuerAirborneRadio") then {
 	TF_defaultGuerAirborneRadio = "tf_anarc164";
 };
 
-if (isNil "TF_give_personal_radio_to_regular_soldier") then {
-	TF_give_personal_radio_to_regular_soldier = false;
-};
-
 if (isNil "TF_terrain_interception_coefficient") then {
 	TF_terrain_interception_coefficient = 7.0;
 };
@@ -77,6 +73,9 @@ disableSerialization;
 waitUntil {sleep 0.2;time > 0};
 if (isNil "tf_no_auto_long_range_radio") then {
 	tf_no_auto_long_range_radio = tf_no_auto_long_range_radio_server;
+};
+if (isNil "TF_give_personal_radio_to_regular_soldier") then {
+	TF_give_personal_radio_to_regular_soldier = TF_give_personal_radio_to_regular_soldier_server;
 };
 waitUntil {sleep 0.1;!(isNull player)};
 titleText [localize ("STR_init"), "PLAIN"];

--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_ServerInit.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_ServerInit.sqf
@@ -29,6 +29,13 @@ if (isNumber (ConfigFile >> "task_force_radio_settings" >> "tf_no_auto_long_rang
 	tf_no_auto_long_range_radio_server = false;
 };
 publicVariable "tf_no_auto_long_range_radio_server";
+if (isNumber (ConfigFile >> "task_force_radio_settings" >> "TF_give_personal_radio_to_regular_soldier")) then {
+	TF_give_personal_radio_to_regular_soldier_server = getNumber (ConfigFile >> "task_force_radio_settings" >> "TF_give_personal_radio_to_regular_soldier") == 1;
+} else {
+	TF_give_personal_radio_to_regular_soldier_server = false;
+};
+publicVariable "TF_give_personal_radio_to_regular_soldier_server";
+
 
 waitUntil {sleep 0.1;time > 0};
 

--- a/arma3/userconfig/task_force_radio/radio_keys.hpp
+++ b/arma3/userconfig/task_force_radio/radio_keys.hpp
@@ -1,5 +1,6 @@
 ﻿class task_force_radio_settings {
 	tf_no_auto_long_range_radio = 0;
+	TF_give_personal_radio_to_regular_soldier = 0;
 };
 class task_force_radio_keys {
 


### PR DESCRIPTION
... the server's userconfig.

Solves: https://github.com/michail-nikolaev/task-force-arma-3-radio/issues/562
