### PR TITLE
Added a function to use positionCameraToWorld for the player's position....

### DIFF
--- a/arma3/@task_force_radio/addons/task_force_radio/CfgFunctions.h
+++ b/arma3/@task_force_radio/addons/task_force_radio/CfgFunctions.h
@@ -150,6 +150,7 @@ class CfgFunctions
 			class getRadioOwner{};
 			class isSameRadio{};
 			class defaultPositionCoordinates{};
+			class useCameraToWorld{};
 			
 			class addEventHandler{};
 			class removeEventHandler{};

--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_useCameraToWorld.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_useCameraToWorld.sqf
@@ -1,0 +1,34 @@
+/*
+ 	Name: TFAR_fnc_useCameraToWorld
+ 	
+ 	Author(s):
+		L-H
+
+ 	Description:
+		Uses positionCameraToWorld instead of the default means of calculating the unit's position for radio use.
+	
+	Parameters:
+		0: OBJECT - unit
+		1: BOOLEAN - Whether to use it or default.
+ 	
+ 	Returns:
+		Nothing
+ 	
+ 	Example:
+		[player, true] call TFAR_fnc_useCameraToWorld;
+*/
+if (_this select 1) exitWith {
+	(_this select 0) setVariable ["TF_fnc_position", {
+		_position = [0,0,0,0];
+		if (_this select 0 == player) then {
+			_position = positionCameraToWorld [0,0,0];
+			_forward = (positionCameraToWorld [0,0,1]) vectorDiff _position;
+			_position set [3, (((_forward select 0) atan2 (_forward select 1)) + 360) % 360];
+		}else{
+			_position = _this call TFAR_fnc_defaultPositionCoordinates;
+		};
+		_position
+	}];
+};
+
+(_this select 0) setVariable ["TF_fnc_position", nil];


### PR DESCRIPTION
... Only works on the player since it uses camera position which is local to each machine.

Should entirely close https://github.com/michail-nikolaev/task-force-arma-3-radio/issues/487
