### PR TITLE
Customizable metaData

### DIFF
--- a/ts/src/plugin.cpp
+++ b/ts/src/plugin.cpp
@@ -1256,7 +1256,8 @@ std::string getConnectionStatusInfo(bool pipeConnected, bool inGame, bool includ
 	std::string addon = serverIdToData[id].addon_version;
 	LeaveCriticalSection(&serverDataCriticalSection);
 
-	std::string result = std::string("[I]Connected[/I] [B]")
+	std::string result = std::string("TFAR")+ (pipeConnected ? "Y" : "N") + (inGame ? "Y" : "N")
+		+"[I]Connected[/I] [B]"
 		+ (pipeConnected ? "Y" : "N") + "[/B] [I]Play[/I] [B]"
 		+ (inGame ? "Y" : "N")
 		+ (includeVersion ? std::string("[/B] [I]P:[/I][B]") + PLUGIN_VERSION + "[/B]" : "")
@@ -2286,7 +2287,7 @@ void ts3plugin_infoData(uint64 serverConnectionHandlerID, uint64 id, enum Plugin
 	{
 		std::string metaData = getMetaData((anyID)id);
 		*data = (char*)malloc(INFODATA_BUFSIZE * sizeof(char));  /* Must be allocated in the plugin! */
-		snprintf(*data, INFODATA_BUFSIZE, "%s", metaData.c_str());  /* bbCode is supported. HTML is not supported */
+		snprintf(*data, INFODATA_BUFSIZE, "%s", metaData.substr(6).c_str());  /* bbCode is supported. HTML is not supported */
 	}
 	else
 	{
@@ -2448,7 +2449,7 @@ bool isPluginEnabledForUser(uint64 serverConnectionHandlerID, anyID clientID)
 	std::string clientInfo = getMetaData(clientID);
 	bool result = false;
 
-	std::string shouldStartWith = getConnectionStatusInfo(true, true, false);
+	std::string shouldStartWith = "TFARYY";
 	std::string clientStatus = std::string(clientInfo);
 	result = startWith(shouldStartWith, clientStatus);
 


### PR DESCRIPTION
Allows user to customize the metaData status message without messing up "isPluginEnabledForUser"