### PR TITLE
Fixed BOOLEAN is not a valid typeName

### DIFF
--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_generateLrSettings.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_generateLrSettings.sqf
@@ -26,7 +26,7 @@ if (isNumber (ConfigFile >> "task_force_radio_settings" >> "tf_default_radioVolu
 _lr_settings = [0, _volume, [], 0, nil, -1, 0, false];
 _set = false;
 _lr_frequencies = [];
-if (typename _this == "BOOLEAN") then {
+if (typename _this == "BOOL") then {
 	if (!_this) then {
 		for "_i" from 0 to TF_MAX_LR_CHANNELS step 1 do {
 			_lr_frequencies set [_i, "50"];

--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_generateSwSettings.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_generateSwSettings.sqf
@@ -26,7 +26,7 @@ _sw_settings = [0, _volume, [], 0, nil, -1, 0, getPlayerUID player, false];
 _set = false;
 _sw_frequencies = [];
 
-if (typename _this == "BOOLEAN") then {
+if (typename _this == "BOOL") then {
 	if (!_this) then {
 		for "_i" from 0 to TF_MAX_CHANNELS step 1 do {
 			_sw_frequencies set [_i, "50"];

--- a/debug/TaskForceRadioDebug.Altis/task_force_radio/functions/fn_generateLrSettings.sqf
+++ b/debug/TaskForceRadioDebug.Altis/task_force_radio/functions/fn_generateLrSettings.sqf
@@ -26,7 +26,7 @@ if (isNumber (ConfigFile >> "task_force_radio_settings" >> "tf_default_radioVolu
 _lr_settings = [0, _volume, [], 0, nil, -1, 0, false];
 _set = false;
 _lr_frequencies = [];
-if (typename _this == "BOOLEAN") then {
+if (typename _this == "BOOL") then {
 	if (!_this) then {
 		for "_i" from 0 to TF_MAX_LR_CHANNELS step 1 do {
 			_lr_frequencies set [_i, "50"];

--- a/debug/TaskForceRadioDebug.Altis/task_force_radio/functions/fn_generateSwSettings.sqf
+++ b/debug/TaskForceRadioDebug.Altis/task_force_radio/functions/fn_generateSwSettings.sqf
@@ -26,7 +26,7 @@ _sw_settings = [0, _volume, [], 0, nil, -1, 0, getPlayerUID player, false];
 _set = false;
 _sw_frequencies = [];
 
-if (typename _this == "BOOLEAN") then {
+if (typename _this == "BOOL") then {
 	if (!_this) then {
 		for "_i" from 0 to TF_MAX_CHANNELS step 1 do {
 			_sw_frequencies set [_i, "50"];


### PR DESCRIPTION
The parameters were always ignored, because it was getting compared to "BOOLEAN", which is not a valid typeName.