### PR TITLE
Fix: allUnits is not guaranteed to include allPlayers

### DIFF
--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_processPlayerPositions.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_processPlayerPositions.sqf
@@ -27,6 +27,10 @@ if !(isNull (findDisplay 46)) then {
 				tf_nearPlayers = call TFAR_fnc_getNearPlayers;
 			};
 
+			_other_units = allUnits - allPlayers; // non player units
+			_other_units = _other_units + allPlayers; // add player units
+			_other_units = _other_units - tf_nearPlayers; // remove near players
+
 			_other_units = allUnits - tf_nearPlayers;
 			
 			tf_farPlayers = [];

--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_processPlayerPositions.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_processPlayerPositions.sqf
@@ -30,8 +30,6 @@ if !(isNull (findDisplay 46)) then {
 			_other_units = allUnits - allPlayers; // non player units
 			_other_units = _other_units + allPlayers; // add player units
 			_other_units = _other_units - tf_nearPlayers; // remove near players
-
-			_other_units = allUnits - tf_nearPlayers;
 			
 			tf_farPlayers = [];
 			tf_farPlayersIndex = 0;	


### PR DESCRIPTION
Fix for: https://github.com/michail-nikolaev/task-force-arma-3-radio/issues/1078

Iam not sure if this is the best way to ensure that we have all players in the array.
It's untested.