### PR TITLE
Load the plugin automatically, unless the user manually disabled it.

### DIFF
--- a/ts/src/plugin.cpp
+++ b/ts/src/plugin.cpp
@@ -2377,7 +2377,7 @@ void ts3plugin_freeMemory(void* data) {
  * This function is optional. If missing, no autoload is assumed.
  */
 int ts3plugin_requestAutoload() {
-	return 0;  /* 1 = request autoloaded, 0 = do not request autoload */
+	return 1;  /* 1 = request autoloaded, 0 = do not request autoload */
 }
 
 /************************** TeamSpeak callbacks ***************************/


### PR DESCRIPTION
I think that a user that installs the plugin either by copying the dlls or by creating a .ts3_plugin and executing it would expect it to be enabled on next TeamSpeak run.
Otherwise he would not install those plugin files at all.

Also this is one less step for people wanting to install the plugin, which also means one less potential problem for them.