### PR TITLE
Replace Outdated EachFrame Code

### DIFF
--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_ClientInit.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_ClientInit.sqf
@@ -271,7 +271,7 @@ tf_msSpectatorPerStepMax = 0.035;
 	
 	if (isMultiplayer) then {
 		call TFAR_fnc_sendVersionInfo;
-        TF_processPlayerPositionsHandler = addMissionEventHandler ["EachFrame", TFAR_fnc_processPlayerPositions];
+        TF_processPlayerPositionsHandler = [TFAR_fnc_processPlayerPositions] call CBA_fnc_addPerFrameHandler;
 	};
 };
 

--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_ClientInit.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_ClientInit.sqf
@@ -271,7 +271,7 @@ tf_msSpectatorPerStepMax = 0.035;
 	
 	if (isMultiplayer) then {
 		call TFAR_fnc_sendVersionInfo;
-		["processPlayerPositionsHandler", "onEachFrame", "TFAR_fnc_processPlayerPositions"] call BIS_fnc_addStackedEventHandler;
+        TF_processPlayerPositionsHandler = addMissionEventHandler ["EachFrame", TFAR_fnc_processPlayerPositions];
 	};
 };
 

--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_ClientInit.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_ClientInit.sqf
@@ -271,7 +271,7 @@ tf_msSpectatorPerStepMax = 0.035;
 	
 	if (isMultiplayer) then {
 		call TFAR_fnc_sendVersionInfo;
-        TF_processPlayerPositionsHandler = [TFAR_fnc_processPlayerPositions] call CBA_fnc_addPerFrameHandler;
+		TF_processPlayerPositionsHandler = [TFAR_fnc_processPlayerPositions] call CBA_fnc_addPerFrameHandler;
 	};
 };
 

--- a/debug/TaskForceRadioDebug.Altis/task_force_radio/functions/fn_ClientInit.sqf
+++ b/debug/TaskForceRadioDebug.Altis/task_force_radio/functions/fn_ClientInit.sqf
@@ -289,7 +289,7 @@ tf_msSpectatorPerStepMax = 0.035;
 	
 	if (isMultiplayer) then {
 		call TFAR_fnc_sendVersionInfo;
-        TF_processPlayerPositionsHandler = addMissionEventHandler ["EachFrame", TFAR_fnc_processPlayerPositions];
+        TF_processPlayerPositionsHandler = [TFAR_fnc_processPlayerPositions] call CBA_fnc_addPerFrameHandler;
 	};
 };
 

--- a/debug/TaskForceRadioDebug.Altis/task_force_radio/functions/fn_ClientInit.sqf
+++ b/debug/TaskForceRadioDebug.Altis/task_force_radio/functions/fn_ClientInit.sqf
@@ -289,7 +289,7 @@ tf_msSpectatorPerStepMax = 0.035;
 	
 	if (isMultiplayer) then {
 		call TFAR_fnc_sendVersionInfo;
-		["processPlayerPositionsHandler", "onEachFrame", "TFAR_fnc_processPlayerPositions"] call BIS_fnc_addStackedEventHandler;
+        TF_processPlayerPositionsHandler = addMissionEventHandler ["EachFrame", TFAR_fnc_processPlayerPositions];
 	};
 };
 

--- a/debug/TaskForceRadioDebug.Altis/task_force_radio/functions/fn_ClientInit.sqf
+++ b/debug/TaskForceRadioDebug.Altis/task_force_radio/functions/fn_ClientInit.sqf
@@ -289,7 +289,7 @@ tf_msSpectatorPerStepMax = 0.035;
 	
 	if (isMultiplayer) then {
 		call TFAR_fnc_sendVersionInfo;
-        TF_processPlayerPositionsHandler = [TFAR_fnc_processPlayerPositions] call CBA_fnc_addPerFrameHandler;
+		TF_processPlayerPositionsHandler = [TFAR_fnc_processPlayerPositions] call CBA_fnc_addPerFrameHandler;
 	};
 };
 


### PR DESCRIPTION
When merged this pull request will replace a call to `BIS_fnc_addStackedEventHandler` with the `addMissionEventHandler` command to make TFAR less vulnerable to the misuse/ abuse of the onEachFrame command.