### PR TITLE
Fixed bugs

### DIFF
--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_radioReplaceProcess.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_radioReplaceProcess.sqf
@@ -48,6 +48,8 @@ while {true} do {
 					};
 					true;
 				} count _items;
+				//Bug fix for sectrator mode, player continue talk after being killed
+				"task_force_radio_pipe" callExtension (format ["RELEASE_ALL_TANGENTS	%1", name _unit]);
 			}];
 			TFAR_currentUnit setVariable ["tf_handlers_set", true];
 		};

--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_radioReplaceProcess.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_radioReplaceProcess.sqf
@@ -48,7 +48,7 @@ while {true} do {
 					};
 					true;
 				} count _items;
-				//Bug fix for sectrator mode, player continue talk after being killed
+				//Bug fix for spectator mode, player continue transmit in teamspeak after being killed during radio transmission 
 				"task_force_radio_pipe" callExtension (format ["RELEASE_ALL_TANGENTS	%1", name _unit]);
 			}];
 			TFAR_currentUnit setVariable ["tf_handlers_set", true];

--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_radioToRequestCount.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_radioToRequestCount.sqf
@@ -74,8 +74,6 @@ TF_settingsToCopy = [];
 } count (items TFAR_currentUnit);
 
 {
-	TFAR_currentUnit unassignItem _x;
-	TFAR_currentUnit removeItem _x;
 	if (_x == "ItemRadio") then {
 		_to_remove set [_forEachIndex, _defaultRadio];
 	};

--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_requestRadios.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_requestRadios.sqf
@@ -60,9 +60,17 @@ if ((time - TF_last_request_time > 3) or {_this}) then {
 		_copyIndex = 0;
 		if ((typename _response) == "ARRAY") then {
 			private ["_radioCount","_settingsCount", "_startIndex"];
+
+			{
+				if (_x == "ItemRadio" || _x in _radiosToRequest) then {
+					TFAR_currentUnit unassignItem _x;					
+					TFAR_currentUnit removeItem _x;					
+				};
+			} forEach items TFAR_currentUnit;
+			
 			_radioCount = count _response;
 			_settingsCount = count TF_SettingsToCopy;
-			_startIndex = 0;
+			_startIndex = 0;			
 			if (_radioCount > 0) then {
 				if (TF_first_radio_request) then {
 					TF_first_radio_request = false;


### PR DESCRIPTION
Two annoying bugs:
1) For games without respawn. If player killed during radio transmission  then transmission continues in teamspeak. Only way to stop it - restart TS. Added RELEASE_ALL_TANGENTS jn killed event.
2) For big (150+ players) games without respawn. Often players kicked by battle eye after mission start. After reconnect player apper without radio.

No way to fix it "localy". Many game servers uses TFAR, if I make fix for one of them, I'll need to use different version for other servers.

Same issues presents in 1.0 branch.