### PR TITLE
Fix the loss of radio

### DIFF
--- a/arma3/@task_force_radio/addons/task_force_radio/functions/fn_setActiveSwRadio.sqf
+++ b/arma3/@task_force_radio/addons/task_force_radio/functions/fn_setActiveSwRadio.sqf
@@ -19,4 +19,8 @@
 _old = (call TFAR_fnc_activeSwRadio);
 TFAR_currentUnit unassignItem _old;
 TFAR_currentUnit assignItem _this;
+_listRadios = TFAR_currentUnit call TFAR_fnc_radiosList;
+if !(_old in _listRadios) then {
+	TFAR_currentUnit addItem _old;
+};
 ["OnSWChange", TFAR_currentUnit, [TFAR_currentUnit, _this, _old]] call TFAR_fnc_fireEventHandlers;

--- a/debug/TaskForceRadioDebug.Altis/task_force_radio/functions/fn_setActiveSwRadio.sqf
+++ b/debug/TaskForceRadioDebug.Altis/task_force_radio/functions/fn_setActiveSwRadio.sqf
@@ -19,4 +19,8 @@
 _old = (call TFAR_fnc_activeSwRadio);
 TFAR_currentUnit unassignItem _old;
 TFAR_currentUnit assignItem _this;
+_listRadios = TFAR_currentUnit call TFAR_fnc_radiosList;
+if !(_old in _listRadios) then {
+	TFAR_currentUnit addItem _old;
+};
 ["OnSWChange", TFAR_currentUnit, [TFAR_currentUnit, _this, _old]] call TFAR_fnc_fireEventHandlers;


### PR DESCRIPTION
If the player inventory is full, then when change the radio, the old one is deleted