### PR TITLE
ACE3-Action: Stereo, inside Vehicles

### DIFF
--- a/addons/core/ACEActions.hpp
+++ b/addons/core/ACEActions.hpp
@@ -4,8 +4,8 @@ class CAManBase: Man {
         class ACE_Equipment {
             class TFAR_Radio {
                 displayName = "Radios";
-                condition = "call TFAR_fnc_haveSWRadio";
-                exceptions[] = {};
+                condition = "(([] call TFAR_fnc_haveSWRadio)||([] call TFAR_fnc_haveLRRadio))";
+                exceptions[] = {"isNotInside","isNotSitting"};
                 statement = "";
                 icon = QPATHTOF(ui\ACE_Interaction_Radio_Icon.paa);
                 insertChildren = "[_player] call TFAR_fnc_addRadiosToACE";
@@ -28,19 +28,4 @@ class CAManBase: Man {
             };
         };
     };
-    //class ACE_Actions {
-    //    class TFAR_Radios {
-    //        displayName = "Radios";
-    //        condition = "count (_target call TFAR_fnc_lrRadiosList) > 0";
-    //        insertChildren = "[_target,true] call TFAR_fnc_addRadiosToACE";
-    //        class TFAR_UseLRRadio {
-    //            displayName = "Radios";
-    //            condition = "true";
-    //            exceptions[] = {};
-    //            statement = "";
-    //            icon = "";
-    //            insertChildren = "[_target] call TFAR_fnc_addRadiosToACE";
-    //        };
-    //    };
-    //};
 };

--- a/addons/core/ACEActions.hpp
+++ b/addons/core/ACEActions.hpp
@@ -5,7 +5,7 @@ class CAManBase: Man {
             class TFAR_Radio {
                 displayName = "Radios";
                 condition = "(([] call TFAR_fnc_haveSWRadio)||([] call TFAR_fnc_haveLRRadio))";
-                exceptions[] = {"isNotInside","isNotSitting"};
+                exceptions[] = {"isNotInside", "isNotSitting", "isNotSwimming"};
                 statement = "";
                 icon = QPATHTOF(ui\ACE_Interaction_Radio_Icon.paa);
                 insertChildren = "[_player] call TFAR_fnc_addRadiosToACE";
@@ -13,7 +13,7 @@ class CAManBase: Man {
             class TFAR_LowerHeadset {
                 displayName = "Lower Headset";
                 condition = "(!(missionNamespace getVariable ['TFAR_core_isHeadsetLowered',false])) && (call TFAR_fnc_haveSWRadio || call TFAR_fnc_haveLRRadio)";
-                //exceptions[] = {};
+                exceptions[] = {"isNotInside", "isNotSitting", "isNotSwimming"};
                 statement = "true call TFAR_fnc_setHeadsetLowered;";
                 //showDisabled = 0;
                 icon = "";
@@ -21,7 +21,7 @@ class CAManBase: Man {
             class TFAR_RaiseHeadset {
                 displayName = "Raise Headset";
                 condition = "(missionNamespace getVariable ['TFAR_core_isHeadsetLowered',false]) && (call TFAR_fnc_haveSWRadio || call TFAR_fnc_haveLRRadio)";
-                //exceptions[] = {};
+                exceptions[] = {"isNotInside", "isNotSitting", "isNotSwimming"};
                 statement = "false call TFAR_fnc_setHeadsetLowered;";
                 //showDisabled = 0;
                 icon = "";

--- a/addons/core/XEH_PREP.sqf
+++ b/addons/core/XEH_PREP.sqf
@@ -8,6 +8,7 @@ PREP(activeLrRadio);
 PREP(activeSwRadio);
 PREP_SUB(events\handler,addEventHandler);
 PREP(addRadiosToACE);
+PREP(addStereoToACE);
 // B
 PREP(backpackLr);
 // C

--- a/addons/core/functions/fnc_addRadiosToACE.sqf
+++ b/addons/core/functions/fnc_addRadiosToACE.sqf
@@ -34,7 +34,7 @@ private _children = [];
                     call TFAR_fnc_onLrDialogOpen;
                 },
                 {true},
-                {},
+                {(_this select 2) call TFAR_fnc_addStereoToACE},
                 [_unit,_x]
             ] call ACE_Interact_Menu_fnc_createAction,
             [],
@@ -58,7 +58,7 @@ if (_LROnly) exitWith {_children};
                     call TFAR_fnc_onSwDialogOpen;
                 },
                 {true},
-                {},
+                {(_this select 2) call TFAR_fnc_addStereoToACE},
                 [_unit,_x]
             ] call ACE_Interact_Menu_fnc_createAction,
             [],

--- a/addons/core/functions/fnc_addStereoToACE.sqf
+++ b/addons/core/functions/fnc_addStereoToACE.sqf
@@ -1,0 +1,55 @@
+#include "script_component.hpp"
+
+/*
+    Name: TFAR_fnc_addStereoToACE
+
+    Author(s):
+        Dorbedo
+
+    Description:
+        Used to provide an array of ace actions to be used as children actions in the interact menu.
+
+    Parameters:
+
+
+    Returns:
+        An array of children ACE actions.
+
+    Example:
+    _grandchildren = [_player,_player,[_radio,0]] call TFAR_fnc_addStereoToACE;
+ */
+
+params ["_unit", "_radio"];
+
+private ["_switchFnc","_switchCheck"];
+
+diag_log format["_this = %1",_this];
+
+if (_radio isEqualType []) then {
+    _switchFnc = {(_this select 2) call TFAR_fnc_setLrStereo;};
+    _switchCheck = {!((((_this select 2)select 0) call TFAR_fnc_getLrStereo) isEqualTo ((_this select 2)select 1))};
+} else {
+    _switchFnc = {(_this select 2) call TFAR_fnc_setSwStereo;};
+    _switchCheck = {!((((_this select 2)select 0) call TFAR_fnc_getSwStereo) isEqualTo ((_this select 2)select 1))};
+};
+
+private _grandchilds = [];
+
+for "_i" from 0 to 2 do {
+    _grandchilds pushBack [
+        [
+            format["TFAR_Stereo_Action_%1_%2", _radio, _i],
+            localize format ["STR_stereo_settings_%1", _i],
+            "",
+            _switchFnc,
+            _switchCheck,
+            {},
+            [_radio, _i]
+        ] call ace_interact_menu_fnc_createAction,
+        [],
+        _unit
+    ];
+};
+
+_grandchilds
+

--- a/addons/core/functions/fnc_addStereoToACE.sqf
+++ b/addons/core/functions/fnc_addStereoToACE.sqf
@@ -10,7 +10,8 @@
         Used to provide an array of ace actions to be used as children actions in the interact menu.
 
     Parameters:
-
+        0: OBJECT - Unit
+        1: STRING/ARRAY - the radio
 
     Returns:
         An array of children ACE actions.
@@ -22,8 +23,6 @@
 params ["_unit", "_radio"];
 
 private ["_switchFnc","_switchCheck"];
-
-diag_log format["_this = %1",_this];
 
 if (_radio isEqualType []) then {
     _switchFnc = {(_this select 2) call TFAR_fnc_setLrStereo;};

--- a/addons/core/functions/fnc_getSwStereo.sqf
+++ b/addons/core/functions/fnc_getSwStereo.sqf
@@ -20,4 +20,4 @@
 */
 params[["_radio","",[""]]];
 
-(_radio call TFAR_fnc_getSwSettings) param [TFAR_SW_STEREO_OFFSET,false]
+(_radio call TFAR_fnc_getSwSettings) param [TFAR_SW_STEREO_OFFSET,0]


### PR DESCRIPTION
* the stereo settings added to the self interaction menu
* fix for the default value in TFAR_fnc_getSwStereo
* add the possibility to interact from inside vehicles, on chairs
* fixes #1328