### PR TITLE
Fix Unsung is overriding the ItemRadio class

### DIFF
--- a/addons/handhelds/radio_ids.hpp
+++ b/addons/handhelds/radio_ids.hpp
@@ -4,6 +4,7 @@
         scope = 1; \
         scopeCurator = 1; \
         scopeArsenal = 1; \
+        ace_arsenal_hide = 1; \
         tf_prototype = 0; \
         tf_radio = 1; \
         ace_arsenal_uniqueBase = QUOTE(baseClass); \

--- a/addons/handhelds/radio_ids.hpp
+++ b/addons/handhelds/radio_ids.hpp
@@ -3,6 +3,7 @@
         displayName = QUOTE(displayNameBase 1); \
         scope = 1; \
         scopeCurator = 1; \
+        scopeArsenal = 1; \
         tf_prototype = 0; \
         tf_radio = 1; \
         ace_arsenal_uniqueBase = QUOTE(baseClass); \


### PR DESCRIPTION
and set `scopeArsenal = 2` ... so any _* radio is in the ACE Arsenal.