### PR TITLE
add keybinds to cycle through radio channels

### DIFF
--- a/addons/core/functions/fnc_initKeybinds.sqf
+++ b/addons/core/functions/fnc_initKeybinds.sqf
@@ -35,6 +35,12 @@ TF_sw_cycle_next_modifiers = [false, true, false];
 TF_sw_cycle_prev_scancode = 26;
 TF_sw_cycle_prev_modifiers = [false, true, false];
 
+TF_sw_cycle_next_channel_scancode = DIK_PRIOR;  // PAGEUP
+TF_sw_cycle_next_channel_modifiers = [false, true, false];
+
+TF_sw_cycle_prev_channel_scancode = DIK_NEXT;   // PAGEDOWN
+TF_sw_cycle_prev_channel_modifiers = [false, true, false];
+
 TF_sw_stereo_both_scancode = DIK_UP;//Arrow up
 TF_sw_stereo_both_modifiers = [false, true, false];
 
@@ -82,6 +88,12 @@ TF_lr_cycle_next_modifiers = [false, true, true];
 
 TF_lr_cycle_prev_scancode = 26;
 TF_lr_cycle_prev_modifiers = [false, true, true];
+
+TF_lr_cycle_next_channel_scancode = DIK_PRIOR;  // PAGEUP
+TF_lr_cycle_next_channel_modifiers = [false, false, true];
+
+TF_lr_cycle_prev_channel_scancode = DIK_NEXT;   // PAGEDOWN
+TF_lr_cycle_prev_channel_modifiers = [false, false, true];
 
 TF_lr_stereo_both_scancode = 200;
 TF_lr_stereo_both_modifiers = [false, false, true];
@@ -166,6 +178,10 @@ private _fnc_localizeLRChannel = {
 ["TFAR", "CycleLRRadiosNext", [localize LSTRING(key_CycleNextLRRadios), localize LSTRING(key_CycleNextLRRadios)], {true}, {["next"] call TFAR_fnc_processLRCycleKeys}, [TF_lr_cycle_next_scancode, TF_lr_cycle_next_modifiers], false] call cba_fnc_addKeybind;
 ["TFAR", "CycleLRRadiosPrev", [localize LSTRING(key_CyclePrevLRRadios), localize LSTRING(key_CyclePrevLRRadios)], {true}, {["prev"] call TFAR_fnc_processLRCycleKeys}, [TF_lr_cycle_prev_scancode, TF_lr_cycle_prev_modifiers], false] call cba_fnc_addKeybind;
 
+["TFAR", "CycleSRRadioChannelNext", [localize LSTRING(key_CycleNextSRChannel), localize LSTRING(key_CycleNextSRChannel)], {true}, {[1, false] call TFAR_fnc_setChannelViaDialog;}, [TF_sw_cycle_next_channel_scancode, TF_sw_cycle_next_channel_modifiers], false] call cba_fnc_addKeybind;
+["TFAR", "CycleSRRadioChannelPrev", [localize LSTRING(key_CyclePrevSRChannel), localize LSTRING(key_CyclePrevSRChannel)], {true}, {[0, false] call TFAR_fnc_setChannelViaDialog;}, [TF_sw_cycle_prev_channel_scancode, TF_sw_cycle_prev_channel_modifiers], false] call cba_fnc_addKeybind;
+["TFAR", "CycleLRRadioChannelNext", [localize LSTRING(key_CycleNextLRChannel), localize LSTRING(key_CycleNextLRChannel)], {true}, {[1, true] call TFAR_fnc_setChannelViaDialog;}, [TF_lr_cycle_next_channel_scancode, TF_lr_cycle_next_channel_modifiers], false] call cba_fnc_addKeybind;
+["TFAR", "CycleLRRadioChannelPrev", [localize LSTRING(key_CyclePrevLRChannel), localize LSTRING(key_CyclePrevLRChannel)], {true}, {[0, true] call TFAR_fnc_setChannelViaDialog;}, [TF_lr_cycle_prev_channel_scancode, TF_lr_cycle_prev_channel_modifiers], false] call cba_fnc_addKeybind;
 
 ["TFAR", "SWStereoBoth", [localize LSTRING(key_SWStereo_Both), localize LSTRING(key_SWStereo_Both)], {[0] call TFAR_fnc_processSWStereoKeys}, {true}, [TF_sw_stereo_both_scancode, TF_sw_stereo_both_modifiers], false] call cba_fnc_addKeybind;
 ["TFAR", "SWStereoLeft", [localize LSTRING(key_SWStereo_Left), localize LSTRING(key_SWStereo_Left)], {[1] call TFAR_fnc_processSWStereoKeys}, {true}, [TF_sw_stereo_left_scancode, TF_sw_stereo_left_modifiers], false] call cba_fnc_addKeybind;

--- a/addons/core/stringtable.xml
+++ b/addons/core/stringtable.xml
@@ -1833,6 +1833,14 @@ Normal radyo su altı radyosuyla iletişim kuramaz (herhangi bir ses gelmez). Da
                 <Chinesesimp>向左循环短程无线电</Chinesesimp>
                 <Russian>Переключить на предыдущую рацию ближней связи</Russian>
             </Key>
+            <Key ID="STR_TFAR_CORE_key_CycleNextSRChannel">
+                <Original>Cycle Next SR Channel</Original>
+                <English>Cycle Next SR Channel</English>
+            </Key>
+            <Key ID="STR_TFAR_CORE_key_CyclePrevSRChannel">
+                <Original>Cycle Previous SR Channel</Original>
+                <English>Cycle Previous SR Channel</English>
+            </Key>
             <Key ID="STR_TFAR_CORE_key_CycleNextLRRadios">
                 <Original>Cycle Next LR Radios</Original>
                 <English>Cycle Next LR Radios</English>
@@ -1850,6 +1858,14 @@ Normal radyo su altı radyosuyla iletişim kuramaz (herhangi bir ses gelmez). Da
                 <Chinese>向左循環長程無線電</Chinese>
                 <Chinesesimp>向左循环长程无线电</Chinesesimp>
                 <Russian>Переключить на предыдущую рацию дальней связи</Russian>
+            </Key>
+            <Key ID="STR_TFAR_CORE_key_CycleNextLRChannel">
+                <Original>Cycle Next LR Channel</Original>
+                <English>Cycle Next LR Channel</English>
+            </Key>
+            <Key ID="STR_TFAR_CORE_key_CyclePrevLRChannel">
+                <Original>Cycle Previous LR Channel</Original>
+                <English>Cycle Previous LR Channel</English>
             </Key>
             <Key ID="STR_TFAR_CORE_key_SWStereo_Both">
                 <Original>SR Stereo: Both</Original>


### PR DESCRIPTION
Add keybinds to cycle through radio channels.

Default keys:
CTRL + PAGEUP: Short Range radio channel increase
CTRL + PAGEDOWN: Short Range radio channel decrease
ALT + PAGEUP: Long Range radio channel increase
ALT + PAGEDOWN: Long Range radio channel decrease

Will require additional translations (only default and English are included).