### PR TITLE
fnc_haveDDRadio rewritten to use config attributes instead of inheritance

### DIFF
--- a/addons/core/CfgWeapons.hpp
+++ b/addons/core/CfgWeapons.hpp
@@ -1,0 +1,6 @@
+class CfgWeapons {
+    class Vest_Camo_Base;
+    class V_RebreatherB: Vest_Camo_Base {
+        tf_hasDDradio = 1;
+    };
+};

--- a/addons/core/config.cpp
+++ b/addons/core/config.cpp
@@ -17,6 +17,7 @@ class CfgPatches {
             "cba_ui",
             "cba_xeh",
             "cba_settings",
+            "A3_Weapons_F", // for overwriting V_RebreatherB with attribute
             "A3_Soft_F_Offroad_01" //Offroad_01_base_F we are adding insolation and LR in CfgVehicles
         };
         author = ECSTRING(core,AUTHORS);
@@ -150,3 +151,4 @@ class ace_arsenal_stats {
 #include "CfgSounds.hpp"
 #include "CfgFontFamilies.hpp"
 #include "CfgVehicles.hpp"
+#include "CfgWeapons.hpp"

--- a/addons/core/functions/fnc_haveDDRadio.sqf
+++ b/addons/core/functions/fnc_haveDDRadio.sqf
@@ -25,12 +25,12 @@
 
 private _checkForRadio = {
     if !(call TFAR_fnc_haveSWRadio) exitWith {false};
-    //#TODO https://community.bistudio.com/wiki/isAbleToBreathe
-    if ((vest TFAR_currentUnit) == "V_RebreatherB") exitWith {true};
 
-    private _rebreather = configFile >> "CfgWeapons" >> "V_RebreatherB";
-    private _currentVest = configFile >> "CfgWeapons" >> (vest TFAR_currentUnit);
-    [_currentVest, _rebreather] call CBA_fnc_inheritsFrom
+    private _hasDDRadio = getNumber(configFile >> "CfgWeapons" >> (vest TFAR_currentUnit) >> "tf_hasDDradio");
+
+    if (_hasDDRadio isEqualTo 1) exitWith {true};
+
+    false;
 };
 
 private _result = call _checkForRadio;


### PR DESCRIPTION
Changed the function haveDDRadio to use a config attribute instead of inheritance from `V_RebreatherB` to determine whether or not a player has a DD radio.

I tried to follow all naming and style rules i could see, if something should be changed feel free to point it out or change it yourself. Feel free to reject if this is not wanted this way.

**When merged this pull request will:**
- not change any noticable feature to a player
- allow developers to define vests as DD radios without having to inherit `V_RebreatherB`
- probably slightly increase performance of `fnc_haveDDRadio.sqf`