### PR TITLE
added ability to set custom teamspeak name

### DIFF
--- a/addons/core/functions/fnc_forceSpectator.sqf
+++ b/addons/core/functions/fnc_forceSpectator.sqf
@@ -25,7 +25,7 @@ params ["_player", "_value"];
 _player call TFAR_fnc_releaseAllTangents; //Stop all radio transmissions
 
 _player setVariable ["TFAR_forceSpectator", _value, true];
-_player setVariable ["TFAR_spectatorName", profileName, true];
+_player setVariable ["TFAR_spectatorName", (TFAR_currentUnit getVariable ["TFAR_unitName", profileName]), true];
 
 if (TFAR_ShowVolumeHUD && _value) then { //Don't have a voice in spectator Mode so hide the HUD
     (QGVAR(HUDVolumeIndicatorRsc) call BIS_fnc_rscLayer) cutText ["", "PLAIN"];

--- a/addons/core/functions/fnc_processPlayerPositions.sqf
+++ b/addons/core/functions/fnc_processPlayerPositions.sqf
@@ -34,7 +34,7 @@ if (!TFAR_currentNearPlayersProcessed) then {
 
     {
         private _controlled = _x getVariable ["TFAR_controlledUnit", objNull];
-        private _unitName = name _x;
+        private _unitName = _x getVariable ["TFAR_unitName", name _x];
         if (_x getVariable ["TFAR_forceSpectator", false]) then {
             _unitName = _x getVariable ["TFAR_spectatorName", _unitName];
         };
@@ -70,7 +70,7 @@ if (!TFAR_currentFarPlayersProcessed) then {
 
     {
         private _controlled = _x getVariable ["TFAR_controlledUnit", objNull];
-        private _unitName = name _x;
+        private _unitName = _x getVariable ["TFAR_unitName", name _x];
         if (_x getVariable ["TFAR_forceSpectator", false]) then {
             _unitName = _x getVariable ["TFAR_spectatorName", _unitName];
         };

--- a/addons/core/functions/plugin/fnc_isSpeaking.sqf
+++ b/addons/core/functions/plugin/fnc_isSpeaking.sqf
@@ -20,7 +20,7 @@
   Public: Yes
 */
 
-private _splitResult = ("task_force_radio_pipe" callExtension format ["IS_SPEAKING	%1", name _this]) splitString "";
+private _splitResult = ("task_force_radio_pipe" callExtension format ["IS_SPEAKING	%1", (_this getVariable ["TFAR_unitName", name _this])]) splitString "";
 
 //_splitResult
 //1 - is Speaking

--- a/addons/core/functions/plugin/fnc_releaseAllTangents.sqf
+++ b/addons/core/functions/plugin/fnc_releaseAllTangents.sqf
@@ -18,4 +18,4 @@
   Public: Yes
 */
 
-"task_force_radio_pipe" callExtension (format ["RELEASE_ALL_TANGENTS	%1~", name _this]);//Async call will always return "OK"
+"task_force_radio_pipe" callExtension (format ["RELEASE_ALL_TANGENTS	%1~",(_this getVariable ["TFAR_unitName", name _this])]);//Async call will always return "OK"

--- a/addons/core/functions/plugin/fnc_sendFrequencyInfo.sqf
+++ b/addons/core/functions/plugin/fnc_sendFrequencyInfo.sqf
@@ -115,7 +115,7 @@ private _alive = alive TFAR_currentUnit;
 
 private _nickname = if (_alive) then {name player} else {profileName};
 
-_nickname = (TFAR_currentUnit getVariable ["TFAR_unitName", _nickname])
+_nickname = (TFAR_currentUnit getVariable ["TFAR_unitName", _nickname]);
 
 private _globalVolume = TFAR_currentUnit getVariable ["tf_globalVolume",1.0];//used API variable. Don't change
 

--- a/addons/core/functions/plugin/fnc_sendFrequencyInfo.sqf
+++ b/addons/core/functions/plugin/fnc_sendFrequencyInfo.sqf
@@ -115,6 +115,8 @@ private _alive = alive TFAR_currentUnit;
 
 private _nickname = if (_alive) then {name player} else {profileName};
 
+_nickname = (TFAR_currentUnit getVariable ["TFAR_unitName", _nickname])
+
 private _globalVolume = TFAR_currentUnit getVariable ["tf_globalVolume",1.0];//used API variable. Don't change
 
 //smaller value == bigger range

--- a/addons/core/functions/plugin/fnc_sendPlayerKilled.sqf
+++ b/addons/core/functions/plugin/fnc_sendPlayerKilled.sqf
@@ -22,5 +22,5 @@ _this setRandomLip false;
 
 _this call TFAR_fnc_releaseAllTangents;
 
-private _request = format["KILLED	%1~", name _this];//Async call will always return "OK"
+private _request = format["KILLED	%1~", (_this getVariable ["TFAR_unitName", name _this])];//Async call will always return "OK"
 _result = "task_force_radio_pipe" callExtension _request;


### PR DESCRIPTION
This addresses the ideas/problems mentioned in #1463 and #1168 by allowing the name shown in TeamSpeak (and therefore used by the plugin) to be dynamically set using the variable `TFAR_unitName`.

**When merged this pull request will:**
- Modify all scripts using the players name to use one stored in a variable instead
- not change anything for players/developers if they don't use this feature

There are 2 considerations that need to be decided before merging this:
- should `TFAR_unitName` be set in some initialization script so defaults must not be used everywhere for performance reasons ? I don't know if this matters.
- can `TFAR_spectatorName` and `TFAR_unitName` be merged in one variable ? i don't see where it is ever set to something different than the players name but i don't know if there is some technical reason.

Using a variable instead of the name directly has been tested on a large scale for the past two years on our server and has so far not revealed any problems.
