### PR TITLE
Added - Check for vehicleIDOverride existing on unit

### DIFF
--- a/addons/core/functions/fnc_vehicleId.sqf
+++ b/addons/core/functions/fnc_vehicleId.sqf
@@ -19,7 +19,7 @@
 */
 params ["_unit"];
 
-if (isNull (objectParent _unit) && isNil _unit getVariable "TFAR_vehicleIDOverride") exitWith {"no"};//Unit is not in vehicle
+if (isNull (objectParent _unit) && isNil {_unit getVariable "TFAR_vehicleIDOverride"}) exitWith {"no"};//Unit is not in vehicle
 private _vehicle = (vehicle _unit);
 private _netID = _vehicle getVariable ["TFAR_vehicleIDOverride", netid _vehicle];
 

--- a/addons/core/functions/fnc_vehicleId.sqf
+++ b/addons/core/functions/fnc_vehicleId.sqf
@@ -19,7 +19,7 @@
 */
 params ["_unit"];
 
-if (isNull (objectParent _unit)) exitWith {"no"};//Unit is not in vehicle
+if (isNull (objectParent _unit) && isNil _unit getVariable "TFAR_vehicleIDOverride") exitWith {"no"};//Unit is not in vehicle
 private _vehicle = (vehicle _unit);
 private _netID = _vehicle getVariable ["TFAR_vehicleIDOverride", netid _vehicle];
 


### PR DESCRIPTION
Why
=================
To allow for intercom use outside of a vehicle, but linked to an
intercom of a vehicle or set of vehicles.

Issue ID: N/A

**When merged this pull request will:**
- Allow units to use the intercom whenever the vehicleIDOverride variable is applied to them
- Intended for behind the scenes use, which is why no 3DEN attributes have been created to accompany this