### PR TITLE
Fix MSVC compile issue with unicode character in stringstream

### DIFF
--- a/ts/src/SharedMemoryHandler.cpp
+++ b/ts/src/SharedMemoryHandler.cpp
@@ -125,7 +125,7 @@ SharedMemoryHandler::SharedMemoryHandler() {
 
         diag << TS_INDENT << TS_INDENT << "hasAsyncRequest: " << pData->hasAsyncRequest() << "\n";
         diag << TS_INDENT << TS_INDENT << "hasSyncRequest: " << pData->hasSyncRequest() << "\n";
-        diag << TS_INDENT << TS_INDENT << "lastGameTick: " << std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now()-pData->getLastGameTick()).count() << u"µs" << "\n";
+        diag << TS_INDENT << TS_INDENT << "lastGameTick: " << std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now()-pData->getLastGameTick()).count() << "us" << "\n";
     });
 
 }


### PR DESCRIPTION
**When merged this pull request will:**
- Allow compiling Teamspeak plugin with latest MSVC 2019