### PR TITLE
Fix hearing alive players from spectator when its disabled

### DIFF
--- a/addons/core/functions/plugin/fnc_sendPluginConfig.sqf
+++ b/addons/core/functions/plugin/fnc_sendPluginConfig.sqf
@@ -19,7 +19,11 @@
 */
 
 
-["minimumPluginVersion", 327] call TFAR_fnc_setPluginSetting; //Keep this as first
+if !(missionNamespace getVariable ["TFAR_spectatorCanHearFriendlies",true]) then {
+    ["minimumPluginVersion", 331] call TFAR_fnc_setPluginSetting; //Temporary until next plugin update. This is only needed when using non-default settings for spectators
+} else {
+    ["minimumPluginVersion", 327] call TFAR_fnc_setPluginSetting; //Keep this as first
+};
 
 ["full_duplex",missionNamespace getVariable ["TFAR_fullDuplex",true]] call TFAR_fnc_setPluginSetting;
 ["addon_version",TFAR_ADDON_VERSION] call TFAR_fnc_setPluginSetting;

--- a/ts/src/plugin.cpp
+++ b/ts/src/plugin.cpp
@@ -502,7 +502,7 @@ void processVoiceData(TSServerID serverConnectionHandlerID, TSClientID clientID,
 
     const bool isSpectator = clientData->isSpectating;
     //NonPure normalPlayer->Spectator
-    const bool isNotHearableInNonPureSpectator = clientDataDir->myClientData->isSpectating && (clientData->isEnemyToPlayer && TFAR::config.get<bool>(Setting::spectatorNotHearEnemies)) && TFAR::config.get<bool>(Setting::spectatorCanHearFriendlies);
+    const bool isNotHearableInNonPureSpectator = clientDataDir->myClientData->isSpectating && ((clientData->isEnemyToPlayer && TFAR::config.get<bool>(Setting::spectatorNotHearEnemies)) || (!clientData->isEnemyToPlayer && !TFAR::config.get<bool>(Setting::spectatorCanHearFriendlies)));
     //Other player is also a spectator. So we always hear him without 3D positioning
     const bool isHearableInPureSpectator = clientDataDir->myClientData->isSpectating && clientData->isSpectating;
     const bool isHearableInSpectator = isHearableInPureSpectator || !isNotHearableInNonPureSpectator;


### PR DESCRIPTION
Fix hearing alive players (enemies/friendlies) when its disabled via settings.
Reason was wrong logic formula for isNotHearableInNonPureSpectator variable.