### PR TITLE
Spectator mute

### DIFF
--- a/addons/core/functions/fnc_initCBASettings.sqf
+++ b/addons/core/functions/fnc_initCBASettings.sqf
@@ -184,7 +184,15 @@
     0
 ] call CBA_Settings_fnc_init;
 
-
+[
+    "TFAR_muteSpectators",
+    "CHECKBOX",
+    [ELSTRING(settings,muteSpectators), ELSTRING(settings,muteSpectators_desc)],
+    localize ELSTRING(settings,clientside),
+    false,
+    0,
+    {["muteSpectators", _this] call TFAR_fnc_setPluginSetting;}
+] call CBA_Settings_fnc_init;
 
 
 

--- a/addons/core/functions/plugin/fnc_sendPluginConfig.sqf
+++ b/addons/core/functions/plugin/fnc_sendPluginConfig.sqf
@@ -43,5 +43,6 @@ if !(missionNamespace getVariable ["TFAR_spectatorCanHearFriendlies",true]) then
 ["disableAutomaticMute", missionNamespace getVariable ["TFAR_disableAutoMute", false]] call TFAR_fnc_setPluginSetting;
 ["noAutomoveSpectator", missionNamespace getVariable ["TFAR_noAutomoveSpectator", true]] call TFAR_fnc_setPluginSetting;
 ["allowDebugging", missionNamespace getVariable ["TFAR_allowDebugging", false]] call TFAR_fnc_setPluginSetting;
+["muteSpectators", missionNamespace getVariable ["TFAR_muteSpectators", false]] call TFAR_fnc_setPluginSetting;
 
 //If you add things that player could change in Mission call this PFH or tell players in WIKI

--- a/addons/core/stringtable.xml
+++ b/addons/core/stringtable.xml
@@ -818,6 +818,14 @@
                 <Czech>Nevynucovat přesun do kanálu TFAR v režimu diváka</Czech>
                 <Russian>Не перемещать принудительно в канал TFAR в режиме наблюдателя</Russian>
             </Key>
+            <Key ID="STR_TFAR_SETTINGS_muteSpectators">
+                <English>Mute other spectators</English>
+                <Czech>Ztišit ostatní diváky</Czech>
+            </Key>
+            <Key ID="STR_TFAR_SETTINGS_muteSpectators_desc">
+                <English>When spectating, mute other spectators and listen to alive players only</English>
+                <Czech>Při sledování ztišit ostatní diváky zatímco lze poslouchat hráče kteří jsou stále živí</Czech>
+            </Key>
             <Key ID="STR_TFAR_SETTINGS_noTSNotConnectedHint">
                 <English>Hide "Not connected" message</English>
                 <German>Verstecke "Not connected" message</German>

--- a/ts/src/plugin.cpp
+++ b/ts/src/plugin.cpp
@@ -501,6 +501,13 @@ void processVoiceData(TSServerID serverConnectionHandlerID, TSClientID clientID,
     //If we are dead we can't hear anyone in seriousMode. And if we are alive we can't hear the dead.
 
     const bool isSpectator = clientData->isSpectating;
+
+    // If I am dead and the speaker spectating, ignore if other spectators should be muted
+    if ((TFAR::config.get<bool>(Setting::muteSpectators)) && clientDataDir->myClientData->isSpectating && isSpectator) {
+        sampleBuffer.setToNull();
+        return;
+    }
+
     //NonPure normalPlayer->Spectator
     const bool isNotHearableInNonPureSpectator = clientDataDir->myClientData->isSpectating && ((clientData->isEnemyToPlayer && TFAR::config.get<bool>(Setting::spectatorNotHearEnemies)) || (!clientData->isEnemyToPlayer && !TFAR::config.get<bool>(Setting::spectatorCanHearFriendlies)));
     //Other player is also a spectator. So we always hear him without 3D positioning

--- a/ts/src/settings.hpp
+++ b/ts/src/settings.hpp
@@ -27,7 +27,8 @@
     XX(voiceCone, true), \
     XX(allowDebugging, true), \
     XX(noAutomoveSpectator, false), \
-    XX(disableAutomaticMute, false)
+    XX(disableAutomaticMute, false), \
+    XX(muteSpectators, false)
 
 #define EnumEntry(x,y) x
 #define EnumString(x,y) #x


### PR DESCRIPTION
**When merged this pull request will:**
- Adds option to mute other spectators

**Requires TS Addon update**
Is there a way to tell clients? Other than the warning of using unsupported config.

Should we also mute the player with this setting on and in spectator, so he doesn't *bother* other spectators unknowingly?

