### PR TITLE
Mute dead players automatically

### DIFF
--- a/addons/core/functions/fnc_preparePositionCoordinates.sqf
+++ b/addons/core/functions/fnc_preparePositionCoordinates.sqf
@@ -37,7 +37,7 @@ if ((_isInVehicle || {!isNil {_unit getVariable "TFAR_vehicleIDOverride"}}) && !
 };
 
 private _eyeDepth = _pos select 2;//Inlined version of TFAR_fnc_eyeDepth to save performance
-private _can_speak = (_eyeDepth > 0 || _isolated_and_inside) && {_isSpectating || {alive _unit}}; //Inlined version of TFAR_fnc_canSpeak to save performance
+private _can_speak = (_eyeDepth > 0 || _isolated_and_inside) && (alive _unit || _isSpectating)}; //Inlined version of TFAR_fnc_canSpeak to save performance
 private _isRemotePlayer = !(_unit isEqualTo TFAR_currentUnit);
 private _useSw = true;
 private _useLr = true;

--- a/addons/core/functions/fnc_preparePositionCoordinates.sqf
+++ b/addons/core/functions/fnc_preparePositionCoordinates.sqf
@@ -37,7 +37,7 @@ if ((_isInVehicle || {!isNil {_unit getVariable "TFAR_vehicleIDOverride"}}) && !
 };
 
 private _eyeDepth = _pos select 2;//Inlined version of TFAR_fnc_eyeDepth to save performance
-private _can_speak = (_eyeDepth > 0 || _isolated_and_inside); //Inlined version of TFAR_fnc_canSpeak to save performance
+private _can_speak = (_eyeDepth > 0 || _isolated_and_inside) && {_isSpectating || {alive _unit}}; //Inlined version of TFAR_fnc_canSpeak to save performance
 private _isRemotePlayer = !(_unit isEqualTo TFAR_currentUnit);
 private _useSw = true;
 private _useLr = true;


### PR DESCRIPTION
**When merged this pull request will:**
- This forces all dead players to be muted, until they are in spectator or have respawned.
- This addresses players still be able to talk when they get killed, before being moved to spectator.
- I could add a setting, but I have a hard time thinking people wanting to not mute dead players until they are in spectator/have been respawned. If you think a setting is necessary, I can add one.