### PR TITLE
TFAR_fnc_activeLrRadio: fix undefined return value

### DIFF
--- a/addons/core/functions/fnc_activeLrRadio.sqf
+++ b/addons/core/functions/fnc_activeLrRadio.sqf
@@ -18,7 +18,7 @@
   Public: Yes
 */
 
-private TF_lr_active_radio = nil;
+TF_lr_active_radio = nil;
 
 private _radios = TFAR_currentUnit call TFAR_fnc_lrRadiosList;
 

--- a/addons/core/functions/fnc_activeLrRadio.sqf
+++ b/addons/core/functions/fnc_activeLrRadio.sqf
@@ -18,6 +18,8 @@
   Public: Yes
 */
 
+private TF_lr_active_radio = nil;
+
 private _radios = TFAR_currentUnit call TFAR_fnc_lrRadiosList;
 
 if (isNil "TF_lr_active_radio") then {


### PR DESCRIPTION
for details see https://github.com/gruppe-adler/Shoot_and_Scoot.Tanoa/issues/44#issuecomment-2322932348

**When merged this pull request will:**
- Ensure that this return value is well defined https://github.com/michail-nikolaev/task-force-arma-3-radio/blob/ce23ed88adc71af3c0f48fdefb52261177bfb0da/addons/core/functions/fnc_activeLrRadio.sqf#L44 
- Makes `fnc_activeLrRadio` consistent with `fnc_activeSwRadio` https://github.com/michail-nikolaev/task-force-arma-3-radio/blob/ce23ed88adc71af3c0f48fdefb52261177bfb0da/addons/core/functions/fnc_activeSwRadio.sqf#L21