### PR TITLE
Stats - Only show Encryption code stat for radios

### DIFF
--- a/addons/core/XEH_PREP.sqf
+++ b/addons/core/XEH_PREP.sqf
@@ -6,6 +6,9 @@ PREP_SUB2(ACEInteraction,getStereoChildren);
 PREP_SUB2(ACEInteraction,getTakeChildren);
 PREP_SUB2(ACEInteraction,takeRadio);
 
+PREP_SUB(stats,statCondition_encryptionCode);
+PREP_SUB(stats,statCondition_isRadio);
+
 // /Events
 PREP_SUB(events\handler,addEventHandler);
 PREP_SUB(events\handler,fireEventHandlers);

--- a/addons/core/config.cpp
+++ b/addons/core/config.cpp
@@ -138,7 +138,7 @@ class ace_arsenal_stats {
         displayName = "Encryption Code";//#Todo Translate
         showText= 1;
         textStatement = QUOTE(params [ARR_2('_stat', '_config')]; private _enc = getText (_config >> _stat select 0); _enc);
-        condition = QUOTE(params [ARR_2('_stat', '_config')]; isText (_config >> _stat select 0) && (getText (_config >> _stat select 0) != ''));
+        condition = QUOTE(call TFAR_fnc_statCondition_encryptionCode);
         tabs[] = {{12, 5}, {}};
     };
 };

--- a/addons/core/functions/stats/fnc_statCondition_encryptionCode.sqf
+++ b/addons/core/functions/stats/fnc_statCondition_encryptionCode.sqf
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+
+/*
+  Name: TFAR_fnc_statCondition_isRadio
+
+  Author: DartRuffian
+    Checks if a given item is a SR or LR radio
+
+  Arguments:
+    Stats  - Stats to use <ARRAY>
+    Config - Config path to item <CONFIG>
+
+  Return Value:
+    Stat text <STRING>
+
+  Example:
+    [["tf_encryptionCode"], _config] call TFAR_fnc_statCondition_isRadio
+
+  Public: Yes
+*/
+
+params ["_stats", "_config"];
+
+[["tf_hasLRradio", "tf_radio"], _config] call TFAR_fnc_statCondition_isRadio && {getNumber (_config >> _stats select 0) != ""}

--- a/addons/core/functions/stats/fnc_statCondition_encryptionCode.sqf
+++ b/addons/core/functions/stats/fnc_statCondition_encryptionCode.sqf
@@ -1,10 +1,10 @@
 #include "script_component.hpp"
 
 /*
-  Name: TFAR_fnc_statCondition_isRadio
+  Name: TFAR_fnc_statCondition_encryptionCode
 
   Author: DartRuffian
-    Checks if a given item is a SR or LR radio
+    Checks if an item is a radio and has an encyrption code
 
   Arguments:
     Stats  - Stats to use <ARRAY>

--- a/addons/core/functions/stats/fnc_statCondition_encryptionCode.sqf
+++ b/addons/core/functions/stats/fnc_statCondition_encryptionCode.sqf
@@ -14,7 +14,7 @@
     Stat text <STRING>
 
   Example:
-    [["tf_encryptionCode"], _config] call TFAR_fnc_statCondition_isRadio
+    [["tf_encryptionCode"], _config] call TFAR_fnc_statCondition_encryptionCode
 
   Public: Yes
 */

--- a/addons/core/functions/stats/fnc_statCondition_encryptionCode.sqf
+++ b/addons/core/functions/stats/fnc_statCondition_encryptionCode.sqf
@@ -11,12 +11,12 @@
     Config - Config path to item <CONFIG>
 
   Return Value:
-    Stat text <STRING>
+    True if item has an encryption code and is a radio, otherwise false <BOOL>
 
   Example:
     [["tf_encryptionCode"], _config] call TFAR_fnc_statCondition_encryptionCode
 
-  Public: Yes
+  Public: No
 */
 
 params ["_stats", "_config"];

--- a/addons/core/functions/stats/fnc_statCondition_isRadio.sqf
+++ b/addons/core/functions/stats/fnc_statCondition_isRadio.sqf
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+
+/*
+  Name: TFAR_fnc_statCondition_isRadio
+
+  Author: DartRuffian
+    Checks if a given item is a SR or LR radio
+
+  Arguments:
+    Stats  - Stats to use <ARRAY>
+    Config - Config path to item <CONFIG>
+
+  Return Value:
+    Stat text <STRING>
+
+  Example:
+    [["tf_hasLRradio", "tf_radio"], _config] call TFAR_fnc_statCondition_isRadio
+
+  Public: Yes
+*/
+
+params ["_stats", "_config"];
+
+getNumber (_config >> _stats select 0) == 1 || {getNumber (_config >> _stats select 1) == 1}

--- a/addons/core/functions/stats/fnc_statCondition_isRadio.sqf
+++ b/addons/core/functions/stats/fnc_statCondition_isRadio.sqf
@@ -11,12 +11,12 @@
     Config - Config path to item <CONFIG>
 
   Return Value:
-    Stat text <STRING>
+    True if given item is a radio, otherwise. <BOOL>
 
   Example:
     [["tf_hasLRradio", "tf_radio"], _config] call TFAR_fnc_statCondition_isRadio
 
-  Public: Yes
+  Public: No
 */
 
 params ["_stats", "_config"];

--- a/addons/core/functions/stats/script_component.hpp
+++ b/addons/core/functions/stats/script_component.hpp
@@ -1,0 +1,1 @@
+#include "\z\tfar\addons\core\script_component.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the encryption code stat showing on non-radio items
- Add generic "isRadio" condition function for other stats to potentially use