### PR TITLE
core/functions: fix TFAR_fnc_defaultPositionCoordinates

### DIFF
--- a/addons/core/functions/fnc_defaultPositionCoordinates.sqf
+++ b/addons/core/functions/fnc_defaultPositionCoordinates.sqf
@@ -23,7 +23,7 @@
 //Implicitly passed by TFAR_fnc_preparePositionCoordinates
 //params ["_unit", "_isNearPlayer"];
 
-if (_isSpectating) exitWith {private _pctw = positionCameraToWorld [0,0,0]; [ATLToASL _pctw, (positionCameraToWorld [0,0,1]) vectorDiff _pctw]};
+if (_isSpectating) exitWith {private _pctw = positionCameraToWorld [0,0,0]; [AGLToASL _pctw, (positionCameraToWorld [0,0,1]) vectorDiff _pctw]};
 
 //If this is not in here then positions inside fast moving vehicles will be weird. But this is also performance intensive
 //if (_isNearPlayer && {vectorMagnitude velocity _unit > 3} && {_unit != TFAR_currentUnit}) exitWith {


### PR DESCRIPTION
Context:
https://discord.com/channels/233658633957802016/235996654455488513/1327757619854577737

**When merged this pull request will:**

- Fix wrong use of ATLToASL instead of AGLToASL when determining unit position
