### PR TITLE
Stats - Fix general type error

### DIFF
--- a/addons/core/functions/stats/fnc_statCondition_encryptionCode.sqf
+++ b/addons/core/functions/stats/fnc_statCondition_encryptionCode.sqf
@@ -21,4 +21,4 @@
 
 params ["_stats", "_config"];
 
-[["tf_hasLRradio", "tf_radio"], _config] call TFAR_fnc_statCondition_isRadio && {getNumber (_config >> _stats select 0) != ""}
+[["tf_hasLRradio", "tf_radio"], _config] call TFAR_fnc_statCondition_isRadio && {getText (_config >> _stats select 0) != ""}


### PR DESCRIPTION
Fix general type error that happens on comparing number with string
```
 2:21:52 Error in expression <{getNumber (_config >> _stats select 0) != ""}
>
 2:21:52   Error position: <!= ""}
>
 2:21:52   Error Общая ошибка в выражении
 2:21:52 File z\tfar\addons\core\functions\stats\fnc_statCondition_encryptionCode.sqf..., line 24
```