### PR TITLE
Translations - Localize encryption code in ACE Arsenal

### DIFF
--- a/addons/core/config.cpp
+++ b/addons/core/config.cpp
@@ -135,7 +135,7 @@ class ace_arsenal_stats {
         scope = 2;
         priority = 1;
         stats[] = {"tf_encryptionCode"};
-        displayName = "Encryption Code";//#Todo Translate
+        displayName = CSTRING(radio_encryption_code);
         showText= 1;
         textStatement = QUOTE(params [ARR_2('_stat', '_config')]; private _enc = getText (_config >> _stat select 0); _enc);
         condition = QUOTE(call TFAR_fnc_statCondition_encryptionCode);

--- a/addons/core/stringtable.xml
+++ b/addons/core/stringtable.xml
@@ -2114,6 +2114,23 @@ Normal radyo su altı radyosuyla iletişim kuramaz (herhangi bir ses gelmez). Da
                 <Chinese>控制</Chinese>
                 <Chinesesimp>控制</Chinesesimp>
             </Key>
+            <Key ID="STR_TFAR_CORE_radio_encryption_code">
+                <Original>Encryption code</Original>
+                <English>Encryption code</English>
+                <Czech>Šifrovací kód</Czech>
+                <French>Code de cryptage</French>
+                <German>Verschlüsselungscode</German>
+                <Italian>Codice di crittografia</Italian>
+                <Polish>Kod szyfrowania</Polish>
+                <Portuguese>Código de criptografia</Portuguese>
+                <Russian>Код шифрования</Russian>
+                <Spanish>Código de cifrado</Spanish>
+                <Turkish>Şifreleme kodu</Turkish>
+                <Japanese>暗号化コード</Japanese>
+                <Korean>암호화 코드</Korean>
+                <Chinese>加密代碼</Chinese>
+                <Chinesesimp>加密代码</Chinesesimp>
+            </Key>
             <Key ID="STR_TFAR_CORE_subject_name">
                 <Original>Radio</Original>
                 <English>Radio</English>


### PR DESCRIPTION
Add translated localization key for radio encryption code.
Replace hardcoded ACE Arsenal stat name "Encryption Code" by localization key.

> Translated to most languages by AI - Claude 3.5