### PR TITLE
Core - Fix bad condition on intercom actions, fix macro not using new functions

### DIFF
--- a/addons/core/intercomConfig/config.cpp
+++ b/addons/core/intercomConfig/config.cpp
@@ -13,8 +13,8 @@ class CfgPatches {
     };
 };
 
-#define Intercom_Condition(chan) [ARR_3(_target,_player,chan)] call FUNC(canSetIntercomChannel)
-#define Intercom_Statement(chan) [ARR_3(_target,_player,chan)] call FUNC(setIntercomChannel)
+#define Intercom_Condition(chan) [ARR_3(_target,_player,chan)] call TFAR_fnc_canSetIntercomChannel
+#define Intercom_Statement(chan) [ARR_3(_target,_player,chan)] call TFAR_fnc_setIntercomChannel
 //INFO! First 20 channels should be reserved for TFAR use.
 
 #define IntercomMacro class ACE_SelfActions : ACE_SelfActions { \

--- a/addons/core/script_macros.hpp
+++ b/addons/core/script_macros.hpp
@@ -67,15 +67,20 @@
                 condition = QUOTE(true); \
                 statement = ""; \
                 icon = ""; \
+                class TFAR_IntercomChannel_disabled { \
+                    displayName = "Disabled"; \
+                    condition = QUOTE([ARR_3(_target,_player,-1)] call FUNC(canSetIntercomChannel)); \
+                    statement = QUOTE([ARR_3(_target,_player,-1)] call FUNC(setIntercomChannel)); \
+                }; \
                 class TFAR_IntercomChannel_1 { \
                     displayName = CSTRING(Intercom_ACESelfAction_Channel1); \
-                    condition = QUOTE(true); \
-                    statement = "(vehicle ACE_Player) setVariable [format ['TFAR_IntercomSlot_%1',(netID ACE_Player)],0,true];"; \
+                    condition = QUOTE([ARR_3(_target,_player,0)] call FUNC(canSetIntercomChannel)); \
+                    statement = QUOTE([ARR_3(_target,_player,0)] call FUNC(setIntercomChannel)); \
                 }; \
                 class TFAR_IntercomChannel_2 { \
                     displayName = CSTRING(Intercom_ACESelfAction_Channel2); \
-                    condition = QUOTE(true); \
-                    statement = "(vehicle ACE_Player) setVariable [format ['TFAR_IntercomSlot_%1',(netID ACE_Player)],1,true];"; \
+                    condition = QUOTE([ARR_3(_target,_player,1)] call FUNC(canSetIntercomChannel)); \
+                    statement = QUOTE([ARR_3(_target,_player,1)] call FUNC(setIntercomChannel)); \
                 }; \
             }; \
         }; \

--- a/addons/core/script_macros.hpp
+++ b/addons/core/script_macros.hpp
@@ -69,18 +69,18 @@
                 icon = ""; \
                 class TFAR_IntercomChannel_disabled { \
                     displayName = "Disabled"; \
-                    condition = QUOTE([ARR_3(_target,_player,-1)] call FUNC(canSetIntercomChannel)); \
-                    statement = QUOTE([ARR_3(_target,_player,-1)] call FUNC(setIntercomChannel)); \
+                    condition = QUOTE([ARR_3(_target,_player,-1)] call TFAR_fnc_canSetIntercomChannel); \
+                    statement = QUOTE([ARR_3(_target,_player,-1)] call TFAR_fnc_setIntercomChannel); \
                 }; \
                 class TFAR_IntercomChannel_1 { \
                     displayName = CSTRING(Intercom_ACESelfAction_Channel1); \
-                    condition = QUOTE([ARR_3(_target,_player,0)] call FUNC(canSetIntercomChannel)); \
-                    statement = QUOTE([ARR_3(_target,_player,0)] call FUNC(setIntercomChannel)); \
+                    condition = QUOTE([ARR_3(_target,_player,0)] call TFAR_fnc_canSetIntercomChannel); \
+                    statement = QUOTE([ARR_3(_target,_player,0)] call TFAR_fnc_setIntercomChannel); \
                 }; \
                 class TFAR_IntercomChannel_2 { \
                     displayName = CSTRING(Intercom_ACESelfAction_Channel2); \
-                    condition = QUOTE([ARR_3(_target,_player,1)] call FUNC(canSetIntercomChannel)); \
-                    statement = QUOTE([ARR_3(_target,_player,1)] call FUNC(setIntercomChannel)); \
+                    condition = QUOTE([ARR_3(_target,_player,1)] call TFAR_fnc_canSetIntercomChannel); \
+                    statement = QUOTE([ARR_3(_target,_player,1)] call TFAR_fnc_setIntercomChannel); \
                 }; \
             }; \
         }; \


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the `MACRO_VEC_ISOLATION_LR_Intercom` not using the functions added in #1571 
- Add Disabled intercom option to `MACRO_VEC_ISOLATION_LR_Intercom`
- Fix bad function names in actions, causing the actions to break