### PR TITLE
Add side-specific names for radio frequencies

### DIFF
--- a/addons/backpacks/anarc164/CfgVehicles.hpp
+++ b/addons/backpacks/anarc164/CfgVehicles.hpp
@@ -12,6 +12,9 @@ class TFAR_anarc164: TFAR_Bag_Base {
     tf_range = 40000;
     tf_encryptionCode = "tf_independent_radio_code";
     tf_dialog = "anarc164_radio_dialog";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 3174;
+    tf_channelNameOffset = 0;
     tf_subtype = "airborne";
     tf_dialogUpdate = "[""%1""] call TFAR_fnc_updateLRDialogToChannel;";
 };

--- a/addons/backpacks/anarc164/ui/anarc164.hpp
+++ b/addons/backpacks/anarc164/ui/anarc164.hpp
@@ -72,6 +72,7 @@ class anarc164_radio_dialog {
         sizeEx = "(((((safezoneW / safezoneH) min 1.2) / 1.2) / 23) * 1.2)";
         tooltip = ECSTRING(core,current_freq);
         canModify = 1;
+        TFAR_CHANNEL_NAME_EDIT_HANDLER(TF_lr_dialog_radio,LR_CHANNEL);
         onKeyUp = QUOTE( \
             if (_this select 1 in [ARR_2(28,156)]) then { \
                 [((ctrlParent (_this select 0))) displayCtrl IDC_ANARC164_EDIT] call TFAR_backpacks_fnc_onButtonClick_Enter; \
@@ -100,8 +101,7 @@ class anarc164_radio_dialog {
         tooltip = ECSTRING(core,clear_frequency);
         action = QUOTE( \
             playSound 'TFAR_rotatorPush'; \
-            ctrlSetText [ARR_2(IDC_ANARC164_EDIT,'')]; \
-            ctrlSetFocus ((findDisplay IDD_ANARC164_RADIO_DIALOG) displayCtrl IDC_ANARC164_EDIT); \
+            [ARR_2((findDisplay IDD_ANARC164_RADIO_DIALOG) displayCtrl IDC_ANARC164_EDIT,LR_CHANNEL)] call TFAR_fnc_clearRadioDialogFrequency; \
         );
     };
     class prev_channel: HiddenRotator {

--- a/addons/backpacks/anarc210/CfgVehicles.hpp
+++ b/addons/backpacks/anarc210/CfgVehicles.hpp
@@ -12,6 +12,9 @@ class TFAR_anarc210: TFAR_Bag_Base {
     tf_range = 40000;
     tf_encryptionCode = "tf_west_radio_code";
     tf_dialog = "anarc210_radio_dialog";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 8423;
+    tf_channelNameOffset = 44;
     tf_subtype = "airborne";
     tf_dialogUpdate = "[""CH%1""] call TFAR_fnc_updateLRDialogToChannel;";
 };

--- a/addons/backpacks/anarc210/ui/anarc210.hpp
+++ b/addons/backpacks/anarc210/ui/anarc210.hpp
@@ -89,6 +89,7 @@ class anarc210_radio_dialog {
         sizeEx = "(((((safezoneW / safezoneH) min 1.2) / 1.2) / 32) * 1.2)";
         tooltip = ECSTRING(core,current_freq);
         canModify = 1;
+        TFAR_CHANNEL_NAME_EDIT_HANDLER(TF_lr_dialog_radio,LR_CHANNEL);
         onKeyUp = QUOTE( \
             if (_this select 1 in [ARR_2(28,156)]) then { \
                 [((ctrlParent (_this select 0))) displayCtrl IDC_ANPRC210_EDIT] call TFAR_backpacks_fnc_onButtonClick_Enter; \
@@ -112,10 +113,7 @@ class anarc210_radio_dialog {
         w = 0.03 * safezoneW;
         h = 0.05 * safezoneH;
         tooltip = ECSTRING(core,clear_frequency);
-        action = QUOTE( \
-            ctrlSetText [ARR_2(IDC_ANPRC210_EDIT, '')]; \
-            ctrlSetFocus ((findDisplay IDD_ANPRC210_RADIO_DIALOG) displayCtrl IDC_ANPRC210_EDIT); \
-        );
+        TFAR_CHANNEL_NAME_CLEAR_ACTION(IDD_ANPRC210_RADIO_DIALOG,IDC_ANPRC210_EDIT,LR_CHANNEL);
     };
     class increase_volume: HiddenRotator {
         idc = IDC_ANPRC210_INCREASE_VOLUME;

--- a/addons/backpacks/anprc155/CfgVehicles.hpp
+++ b/addons/backpacks/anprc155/CfgVehicles.hpp
@@ -12,6 +12,9 @@ class TFAR_anprc155: TFAR_Bag_Base {
     hiddenSelectionsTextures[] = {QPATHTOF(models\data\clf_nicecomm2_aff_digital_co.paa)};
     tf_encryptionCode = "tf_independent_radio_code";
     tf_dialog = "anprc155_radio_dialog";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 7666;
+    tf_channelNameOffset = 44;
     tf_subtype = "digital_lr";
 };
 HIDDEN_CLASS(tf_anprc155 : TFAR_anprc155); //#Deprecated dummy class for backwards compat

--- a/addons/backpacks/anprc155/ui/anprc155.hpp
+++ b/addons/backpacks/anprc155/ui/anprc155.hpp
@@ -66,6 +66,7 @@ class anprc155_radio_dialog {
         tooltip = ECSTRING(core,current_freq);
         moving = 1;
         canModify = 1;
+        TFAR_CHANNEL_NAME_EDIT_HANDLER(TF_lr_dialog_radio,LR_CHANNEL);
         onKeyUp = QUOTE( \
             if (_this select 1 in [ARR_2(28,156)]) then { \
                 [((ctrlParent (_this select 0))) displayCtrl IDC_ANPRC155_EDIT] call TFAR_backpacks_fnc_onButtonClick_Enter; \
@@ -89,10 +90,7 @@ class anprc155_radio_dialog {
         w = 0.0180469 * safezoneW;
         h = 0.0286 * safezoneH;
         tooltip = ECSTRING(core,clear_frequency);
-        action = QUOTE( \
-            ctrlSetText [ARR_2(IDC_ANPRC155_EDIT, '')]; \
-            ctrlSetFocus ((findDisplay IDD_ANPRC155_RADIO_DIALOG) displayCtrl IDC_ANPRC155_EDIT); \
-        );
+        TFAR_CHANNEL_NAME_CLEAR_ACTION(IDD_ANPRC155_RADIO_DIALOG,IDC_ANPRC155_EDIT,LR_CHANNEL);
     };
     class prev_channel: HiddenButton {
         idc = IDC_ANPRC155_PREV_CHANNEL;

--- a/addons/backpacks/bussole/CfgVehicles.hpp
+++ b/addons/backpacks/bussole/CfgVehicles.hpp
@@ -12,6 +12,9 @@ class TFAR_bussole: TFAR_Bag_Base {
     hiddenSelectionsTextures[] = {""};
     tf_encryptionCode = "tf_east_radio_code";
     tf_dialog = "bussole_radio_dialog";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 8666;
+    tf_channelNameOffset = 44;
     tf_subtype = "digital_lr";
 };
 HIDDEN_CLASS(tf_bussole : TFAR_bussole); //#Deprecated dummy class for backwards compat

--- a/addons/backpacks/bussole/ui/bussole.hpp
+++ b/addons/backpacks/bussole/ui/bussole.hpp
@@ -87,6 +87,7 @@ class bussole_radio_dialog {
         moving = 1;
         canModify = 1;
         sizeEx = 0.06;
+        TFAR_CHANNEL_NAME_EDIT_HANDLER(TF_lr_dialog_radio,LR_CHANNEL);
         onKeyUp = QUOTE( \
             if (_this select 1 in [ARR_2(28,156)]) then { \
                 [((ctrlParent (_this select 0))) displayCtrl IDC_BUSSOLE_EDIT] call TFAR_backpacks_fnc_onButtonClick_Enter; \
@@ -110,10 +111,7 @@ class bussole_radio_dialog {
         w = 0.020625 * safezoneW;
         h = 0.0286 * safezoneH;
         tooltip = ECSTRING(core,clear_frequency);
-        action = QUOTE( \
-            ctrlSetText [ARR_2(IDC_BUSSOLE_EDIT, '')]; \
-            ctrlSetFocus ((findDisplay IDD_BUSSOLE_RADIO_DIALOG) displayCtrl IDC_BUSSOLE_EDIT); \
-        );
+        TFAR_CHANNEL_NAME_CLEAR_ACTION(IDD_BUSSOLE_RADIO_DIALOG,IDC_BUSSOLE_EDIT,LR_CHANNEL);
     };
     class prev_channel: HiddenButton {
         idc = IDC_BUSSOLE_PREV_CHANNEL;

--- a/addons/backpacks/enoch/CfgVehicles.hpp
+++ b/addons/backpacks/enoch/CfgVehicles.hpp
@@ -2,6 +2,9 @@ class B_RadioBag_01_base_F;
 
 class B_RadioBag_01_black_F: B_RadioBag_01_base_F {
     tf_dialog = "anprc155_radio_dialog";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 7666;
+    tf_channelNameOffset = 44;
     tf_dialogUpdate = "call TFAR_fnc_updateLRDialogToChannel;";
     tf_encryptionCode = "tf_independent_radio_code";
     tf_hasLRradio = 1;
@@ -11,6 +14,9 @@ class B_RadioBag_01_black_F: B_RadioBag_01_base_F {
 
 class B_RadioBag_01_digi_F: B_RadioBag_01_base_F {
     tf_dialog = "anprc155_radio_dialog";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 7666;
+    tf_channelNameOffset = 44;
     tf_dialogUpdate = "call TFAR_fnc_updateLRDialogToChannel;";
     tf_encryptionCode = "tf_independent_radio_code";
     tf_hasLRradio = 1;
@@ -20,6 +26,9 @@ class B_RadioBag_01_digi_F: B_RadioBag_01_base_F {
 
 class B_RadioBag_01_eaf_F: B_RadioBag_01_base_F {
     tf_dialog = "anprc155_radio_dialog";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 7666;
+    tf_channelNameOffset = 44;
     tf_dialogUpdate = "call TFAR_fnc_updateLRDialogToChannel;";
     tf_encryptionCode = "tf_independent_radio_code";
     tf_hasLRradio = 1;
@@ -29,6 +38,9 @@ class B_RadioBag_01_eaf_F: B_RadioBag_01_base_F {
 
 class B_RadioBag_01_ghex_F: B_RadioBag_01_base_F {
     tf_dialog = "bussole_radio_dialog";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 8666;
+    tf_channelNameOffset = 44;
     tf_dialogUpdate = "call TFAR_fnc_updateLRDialogToChannel;";
     tf_encryptionCode = "tf_east_radio_code";
     tf_hasLRradio = 1;
@@ -38,6 +50,9 @@ class B_RadioBag_01_ghex_F: B_RadioBag_01_base_F {
 
 class B_RadioBag_01_hex_F: B_RadioBag_01_base_F {
     tf_dialog = "bussole_radio_dialog";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 8666;
+    tf_channelNameOffset = 44;
     tf_dialogUpdate = "call TFAR_fnc_updateLRDialogToChannel;";
     tf_encryptionCode = "tf_east_radio_code";
     tf_hasLRradio = 1;
@@ -47,6 +62,9 @@ class B_RadioBag_01_hex_F: B_RadioBag_01_base_F {
 
 class B_RadioBag_01_mtp_F: B_RadioBag_01_base_F {
     tf_dialog = "rt1523g_radio_dialog";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 1666;
+    tf_channelNameOffset = 44;
     tf_dialogUpdate = "call TFAR_fnc_updateLRDialogToChannel;";
     tf_encryptionCode = "tf_west_radio_code";
     tf_hasLRradio = 1;
@@ -56,6 +74,9 @@ class B_RadioBag_01_mtp_F: B_RadioBag_01_base_F {
 
 class B_RadioBag_01_tropic_F: B_RadioBag_01_base_F {
     tf_dialog = "rt1523g_radio_dialog";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 1666;
+    tf_channelNameOffset = 44;
     tf_dialogUpdate = "call TFAR_fnc_updateLRDialogToChannel;";
     tf_encryptionCode = "tf_west_radio_code";
     tf_hasLRradio = 1;
@@ -65,6 +86,9 @@ class B_RadioBag_01_tropic_F: B_RadioBag_01_base_F {
 
 class B_RadioBag_01_oucamo_F: B_RadioBag_01_base_F {
     tf_dialog = "bussole_radio_dialog";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 8666;
+    tf_channelNameOffset = 44;
     tf_dialogUpdate = "call TFAR_fnc_updateLRDialogToChannel;";
     tf_encryptionCode = "tf_east_radio_code";
     tf_hasLRradio = 1;
@@ -74,6 +98,9 @@ class B_RadioBag_01_oucamo_F: B_RadioBag_01_base_F {
 
 class B_RadioBag_01_wdl_F: B_RadioBag_01_base_F {
     tf_dialog = "rt1523g_radio_dialog";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 1666;
+    tf_channelNameOffset = 44;
     tf_dialogUpdate = "call TFAR_fnc_updateLRDialogToChannel;";
     tf_encryptionCode = "tf_west_radio_code";
     tf_hasLRradio = 1;

--- a/addons/backpacks/mr3000/CfgVehicles.hpp
+++ b/addons/backpacks/mr3000/CfgVehicles.hpp
@@ -12,6 +12,9 @@ class TFAR_mr3000: TFAR_Bag_Base {
     hiddenSelectionsTextures[] = {QPATHTOF(models\data\clf_nicecomm2_csat_multi_co.paa)};
     tf_encryptionCode = "tf_east_radio_code";
     tf_dialog = "mr3000_radio_dialog";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 1998;
+    tf_channelNameOffset = 44;
     tf_subtype = "digital_lr";
 };
 HIDDEN_CLASS(tf_mr3000 : TFAR_mr3000); //#Deprecated dummy class for backwards compat

--- a/addons/backpacks/mr3000/ui/mr3000.hpp
+++ b/addons/backpacks/mr3000/ui/mr3000.hpp
@@ -86,9 +86,7 @@ class mr3000_radio_dialog {
         w = 0.0223125 * safezoneW;
         h = 0.0308069 * safezoneH;
         tooltip = ECSTRING(core,clear_frequency);
-        action = QUOTE(ctrlSetText [ARR_2(IDC_MR3000_EDIT, '')]; \
-            ctrlSetFocus ((findDisplay IDD_MR3000_RADIO_DIALOG) displayCtrl IDC_MR3000_EDIT); \
-        );
+        TFAR_CHANNEL_NAME_CLEAR_ACTION(IDD_MR3000_RADIO_DIALOG,IDC_MR3000_EDIT,LR_CHANNEL);
     };
     class next_channel: HiddenButton {
         idc = IDC_MR3000_NEXT_CHANNEL;
@@ -218,6 +216,7 @@ class mr3000_radio_dialog {
         sizeEx = "(((((safezoneW / safezoneH) min 1.2) / 1.2) / 30) * 1.2)";
         tooltip = ECSTRING(core,current_freq);
         canModify = 1;
+        TFAR_CHANNEL_NAME_EDIT_HANDLER(TF_lr_dialog_radio,LR_CHANNEL);
         onKeyUp = QUOTE( \
             if (_this select 1 in [ARR_2(28,156)]) then { \
                 [((ctrlParent (_this select 0))) displayCtrl IDC_MR3000_EDIT] call TFAR_backpacks_fnc_onButtonClick_Enter; \

--- a/addons/backpacks/mr6000l/CfgVehicles.hpp
+++ b/addons/backpacks/mr6000l/CfgVehicles.hpp
@@ -10,6 +10,9 @@ class TFAR_mr6000l: TFAR_Bag_Base {
     tf_range = 40000;
     tf_encryptionCode = "tf_east_radio_code";
     tf_dialog = "mr6000l_radio_dialog";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 20135;
+    tf_channelNameOffset = 0;
     tf_subtype = "airborne";
     tf_dialogUpdate = "[""PRE %1""] call TFAR_fnc_updateLRDialogToChannel;";
 };

--- a/addons/backpacks/mr6000l/ui/mr6000l.hpp
+++ b/addons/backpacks/mr6000l/ui/mr6000l.hpp
@@ -90,6 +90,7 @@ class mr6000l_radio_dialog {
         sizeEx = "(((((safezoneW / safezoneH) min 1.2) / 1.2) / 22) * 1.2)";
         tooltip = ECSTRING(core,current_freq);
         canModify = 1;
+        TFAR_CHANNEL_NAME_EDIT_HANDLER(TF_lr_dialog_radio,LR_CHANNEL);
         onKeyUp = QUOTE( \
             if (_this select 1 in [ARR_2(28,156)]) then { \
                 [((ctrlParent (_this select 0))) displayCtrl IDC_MR6000L_EDIT] call TFAR_backpacks_fnc_onButtonClick_Enter; \
@@ -113,10 +114,7 @@ class mr6000l_radio_dialog {
         w = 0.03 * safezoneW;
         h = 0.05 * safezoneH;
         tooltip = ECSTRING(core,clear_frequency);
-        action = QUOTE( \
-            ctrlSetText [ARR_2(IDC_MR6000L_EDIT, '')]; \
-            ctrlSetFocus ((findDisplay IDD_MR6000L_RADIO_DIALOG) displayCtrl IDC_MR6000L_EDIT); \
-        );
+        TFAR_CHANNEL_NAME_CLEAR_ACTION(IDD_MR6000L_RADIO_DIALOG,IDC_MR6000L_EDIT,LR_CHANNEL);
     };
     class prev_channel: HiddenButton {
         idc = IDC_MR6000L_PREV_CHANNEL;

--- a/addons/backpacks/rt1523g/CfgVehicles.hpp
+++ b/addons/backpacks/rt1523g/CfgVehicles.hpp
@@ -12,6 +12,9 @@ class TFAR_rt1523g: TFAR_Bag_Base {
     mass = 80;
     tf_encryptionCode = "tf_west_radio_code";
     tf_dialog = "rt1523g_radio_dialog";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 1666;
+    tf_channelNameOffset = 44;
     tf_subtype = "digital_lr";
 };
 HIDDEN_CLASS(tf_rt1523g : TFAR_rt1523g); //#Deprecated dummy class for backwards compat

--- a/addons/backpacks/rt1523g/ui/rt1523g.hpp
+++ b/addons/backpacks/rt1523g/ui/rt1523g.hpp
@@ -73,6 +73,7 @@ class rt1523g_radio_dialog {
         shadow = 2;
         tooltip = ECSTRING(core,current_freq);
         canModify = 1;
+        TFAR_CHANNEL_NAME_EDIT_HANDLER(TF_lr_dialog_radio,LR_CHANNEL);
         onKeyUp = QUOTE( \
             if (_this select 1 in [ARR_2(28,156)]) then { \
                 [((ctrlParent (_this select 0))) displayCtrl IDC_RT1523G_EDIT] call TFAR_backpacks_fnc_onButtonClick_Enter; \
@@ -98,10 +99,7 @@ class rt1523g_radio_dialog {
         w = 0.036975 * safezoneW;
         h = 0.0403769 * safezoneH;
         tooltip = ECSTRING(core,clear_frequency);
-        action = QUOTE( \
-            ctrlSetText [ARR_2(IDC_RT1523G_EDIT, '')]; \
-            ctrlSetFocus ((findDisplay IDD_RT1523G_RADIO_DIALOG) displayCtrl IDC_RT1523G_EDIT); \
-        );
+        TFAR_CHANNEL_NAME_CLEAR_ACTION(IDD_RT1523G_RADIO_DIALOG,IDC_RT1523G_EDIT,LR_CHANNEL);
     };
     class enter: HiddenButton {
         idc = IDC_RT1523G_ENTER;

--- a/addons/backpacks/uiDefines.hpp
+++ b/addons/backpacks/uiDefines.hpp
@@ -7,6 +7,11 @@ class HiddenRotator;
 class HiddenFlip;
 
 #define TF_IDD_BACKGROUND 67676
+
+#define TFAR_CHANNEL_NAME_EDIT_HANDLER(RADIO,CHANNEL_IDC) \
+    onMouseButtonDown = QUOTE([ARR_4(_this select 0,RADIO,true,CHANNEL_IDC)] call TFAR_fnc_showRadioDialogFrequency;)
+#define TFAR_CHANNEL_NAME_CLEAR_ACTION(DISPLAY_IDD,EDIT_IDC,CHANNEL_IDC) \
+    action = QUOTE([ARR_2((findDisplay DISPLAY_IDD) displayCtrl EDIT_IDC,CHANNEL_IDC)] call TFAR_fnc_clearRadioDialogFrequency;)
 //--- rt1523g_radio_dialog
 #define IDD_RT1523G_RADIO_DIALOG  1666
 #define IDC_RT1523G_BACKGROUND TF_IDD_BACKGROUND

--- a/addons/core/XEH_PREP.sqf
+++ b/addons/core/XEH_PREP.sqf
@@ -98,6 +98,7 @@ PREP_SUB(server,serverInit);
 // A
 PREP(activeLrRadio);
 PREP(activeSwRadio);
+PREP(applyFrequencyNamesSetting);
 PREP(addDiaryRecord);
 // B
 PREP(backpackLr);
@@ -109,6 +110,7 @@ PREP(canUseLRRadio);
 PREP(canUseDDRadio);
 PREP(clientInit);
 PREP(copySettings);
+PREP(clearRadioDialogFrequency);
 PREP(currentDirection);
 PREP(currentLRFrequency);
 PREP(currentSWFrequency);
@@ -122,6 +124,7 @@ PREP(doSRTransmitEnd);
 // E
 PREP(eyeDepth);
 // F
+PREP(formatChannel);
 PREP(forceSpectator);
 // G
 PREP(generateLrSettings);
@@ -134,6 +137,8 @@ PREP(getSwChannel);
 PREP(getLrChannel);
 PREP(getSwStereo);
 PREP(getSwFrequency);
+PREP(getRadioDialogFrequencyPosition);
+PREP(getSwDialogFrequencyPosition);
 PREP(getLrFrequency);
 PREP(getLrStereo);
 PREP(getSwVolume);
@@ -146,6 +151,9 @@ PREP(getWeaponConfigProperty);
 PREP(getCopilot);
 PREP(getLrRadioProperty);
 PREP(getChannelFrequency);
+PREP(getChannelName);
+PREP(getFrequencyName);
+PREP(getRadioSide);
 PREP(getRadioItems);
 PREP(getSideRadio);
 PREP(getTransmittingDistanceMultiplicator);
@@ -189,6 +197,7 @@ PREP(objectInterception);
 PREP(objectInterceptionBulkToCache);
 // P
 PREP(parseFrequenciesInput);
+PREP(parseFrequencyNamesInput);
 PREP(preparePositionCoordinates);
 PREP(processPlayerPositions);
 PREP(processRespawn);
@@ -224,10 +233,13 @@ PREP(setActiveLrRadio);
 PREP(setLongRangeRadioFrequency);
 PREP(setPersonalRadioFrequency);
 PREP(setChannelFrequency);
+PREP(setFrequencyName);
 PREP(setRadioOwner);
 PREP(setLrSpeakers);
 PREP(settingForceArray);
+PREP(showRadioDialogFrequency);
 // U
+PREP(updateRadioDialogFrequency);
 PREP(updateSpeakVolumeUI);
 // V
 PREP(vehicleId);

--- a/addons/core/defines.hpp
+++ b/addons/core/defines.hpp
@@ -28,6 +28,8 @@
 #define TFAR_FREQUENCYSTRING_TO_FREQNUMBER(frequency) parseNumber ( ((frequency) splitString ",.") joinString "." )
 
 #define TFAR_MAX_CHANNELS 8
+#define TFAR_MAX_CHANNEL_NAME_LENGTH 8
+#define TFAR_MAX_FREQUENCY_NAMES 16
 #define TFAR_MIN_SW_FREQ 30
 #define TFAR_MAX_SW_FREQ 512
 

--- a/addons/core/functions/events/ui/fnc_updateLRDialogToChannel.sqf
+++ b/addons/core/functions/events/ui/fnc_updateLRDialogToChannel.sqf
@@ -27,10 +27,34 @@ if ((_this isEqualType []) and {count _this > 0} and  {(_this select 0) isEqualT
     _formatText = _this select 0;
 };
 
-if ((TF_lr_dialog_radio call TFAR_fnc_getAdditionalLrChannel) == (TF_lr_dialog_radio call TFAR_fnc_getLrChannel)) then {
+private _channel = TF_lr_dialog_radio call TFAR_fnc_getLrChannel;
+
+if ((TF_lr_dialog_radio call TFAR_fnc_getAdditionalLrChannel) == _channel) then {
     _formatText = "CA:%1";
 };
 
-ctrlSetText [LR_EDIT, TF_lr_dialog_radio call TFAR_fnc_getLrFrequency];
-private _channelText =  format[_formatText, (TF_lr_dialog_radio call TFAR_fnc_getLrChannel) + 1];
+private _frequency = TF_lr_dialog_radio call TFAR_fnc_getLrFrequency;
+private _channelName = [TF_lr_dialog_radio, _channel + 1] call TFAR_fnc_getChannelName;
+private _radioObject = TF_lr_dialog_radio select 0;
+private _showChannelName = _channelName isNotEqualTo "" && {
+    [_radioObject, "tf_showChannelName", 0] call TFAR_fnc_getLrRadioProperty > 0
+};
+
+private _dialogIdd = [_radioObject, "tf_channelNameDialogIdd", -1] call TFAR_fnc_getLrRadioProperty;
+private _offsetPixels = [_radioObject, "tf_channelNameOffset", 0] call TFAR_fnc_getLrRadioProperty;
+
+if !(_dialogIdd isEqualType 0) then {_dialogIdd = -1;};
+if !(_offsetPixels isEqualType 0) then {_offsetPixels = 0;};
+
+[
+    _frequency,
+    _channelName,
+    _showChannelName,
+    _dialogIdd,
+    _offsetPixels,
+    LR_EDIT,
+    LR_CHANNEL
+] call TFAR_fnc_updateRadioDialogFrequency;
+
+private _channelText = format [_formatText, _channel + 1];
 ctrlSetText [LR_CHANNEL, _channelText];

--- a/addons/core/functions/events/ui/fnc_updateSWDialogToChannel.sqf
+++ b/addons/core/functions/events/ui/fnc_updateSWDialogToChannel.sqf
@@ -27,10 +27,33 @@ if ((_this isEqualType []) and {count _this > 0} and  {(_this select 0) isEqualT
     _formatText = _this select 0;
 };
 
-if ((TF_sw_dialog_radio call TFAR_fnc_getAdditionalSwChannel) == (TF_sw_dialog_radio call TFAR_fnc_getSwChannel)) then {
+private _channel = TF_sw_dialog_radio call TFAR_fnc_getSwChannel;
+
+if ((TF_sw_dialog_radio call TFAR_fnc_getAdditionalSwChannel) == _channel) then {
     _formatText = "A%1";
 };
 
-ctrlSetText [SW_EDIT, TF_sw_dialog_radio call TFAR_fnc_getSwFrequency];
-private _channelText =  format[_formatText, (TF_sw_dialog_radio call TFAR_fnc_getSwChannel) + 1];
+private _frequency = TF_sw_dialog_radio call TFAR_fnc_getSwFrequency;
+private _channelName = [TF_sw_dialog_radio, _channel + 1] call TFAR_fnc_getChannelName;
+private _showChannelName = _channelName isNotEqualTo "" && {
+    [TF_sw_dialog_radio, "tf_showChannelName", 0] call DFUNC(getWeaponConfigProperty) > 0
+};
+
+private _dialogIdd = [TF_sw_dialog_radio, "tf_channelNameDialogIdd", -1] call DFUNC(getWeaponConfigProperty);
+private _offsetPixels = [TF_sw_dialog_radio, "tf_channelNameOffset", 0] call DFUNC(getWeaponConfigProperty);
+
+if !(_dialogIdd isEqualType 0) then {_dialogIdd = -1;};
+if !(_offsetPixels isEqualType 0) then {_offsetPixels = 0;};
+
+[
+    _frequency,
+    _channelName,
+    _showChannelName,
+    _dialogIdd,
+    _offsetPixels,
+    SW_EDIT,
+    SW_CHANNEL
+] call TFAR_fnc_updateRadioDialogFrequency;
+
+private _channelText = format [_formatText, _channel + 1];
 ctrlSetText [SW_CHANNEL, _channelText];

--- a/addons/core/functions/fnc_applyFrequencyNamesSetting.sqf
+++ b/addons/core/functions/fnc_applyFrequencyNamesSetting.sqf
@@ -1,0 +1,35 @@
+#include "script_component.hpp"
+
+/*
+  Name: TFAR_fnc_applyFrequencyNamesSetting
+
+  Author: Darojax
+    Parses a CBA frequency-name setting and publishes its canonical table.
+
+  Arguments:
+    0: CBA setting value <STRING>
+    1: Canonical mission namespace variable <STRING>
+    2: Is long-range frequency list <BOOL>
+
+  Return Value:
+    None
+
+  Public: No
+*/
+
+params [
+    ["_value", "", [""]],
+    ["_variableName", "", [""]],
+    ["_isLrRadio", false, [false]]
+];
+
+if (_variableName isEqualTo "") exitWith {};
+
+private _definitions = [_value, _isLrRadio] call TFAR_fnc_parseFrequencyNamesInput;
+if (isServer) then {
+    missionNamespace setVariable [_variableName, _definitions, true];
+} else {
+    if (isNil {missionNamespace getVariable _variableName}) then {
+        missionNamespace setVariable [_variableName, _definitions];
+    };
+};

--- a/addons/core/functions/fnc_clearRadioDialogFrequency.sqf
+++ b/addons/core/functions/fnc_clearRadioDialogFrequency.sqf
@@ -1,0 +1,30 @@
+#include "script_component.hpp"
+
+/*
+  Name: TFAR_fnc_clearRadioDialogFrequency
+
+  Author: Darojax
+    Restores a radio's original frequency-control geometry and prepares it for
+    manual frequency entry.
+
+  Arguments:
+    0: Frequency edit control <CONTROL>
+    1: Channel control IDC <NUMBER>
+
+  Return Value:
+    None
+
+  Public: No
+*/
+
+params [
+    ["_frequencyControl", controlNull, [controlNull]],
+    ["_channelControlIdc", -1, [0]]
+];
+
+if (isNull _frequencyControl) exitWith {};
+
+_frequencyControl ctrlSetPosition ([_frequencyControl, _channelControlIdc] call TFAR_fnc_getRadioDialogFrequencyPosition);
+_frequencyControl ctrlCommit 0;
+_frequencyControl ctrlSetText "";
+ctrlSetFocus _frequencyControl;

--- a/addons/core/functions/fnc_doLRTransmit.sqf
+++ b/addons/core/functions/fnc_doLRTransmit.sqf
@@ -44,7 +44,7 @@ private _hintText = format[
                                     ([_radio select 0, "displayName"] call TFAR_fnc_getLrRadioProperty) select [0, MAX_RADIONAME_LEN],
                                     getText(configFile >> "CfgVehicles" >> typeOf (_radio select 0) >> "picture")
                                     ],
-                            _channel + 1,
+                            [_radio, _channel + 1] call TFAR_fnc_formatChannel,
                             _frequency
                         ];
 private _pluginCommand = format[

--- a/addons/core/functions/fnc_doLRTransmitEnd.sqf
+++ b/addons/core/functions/fnc_doLRTransmitEnd.sqf
@@ -33,7 +33,7 @@ private _hintText = format[
                                 ([_radio select 0, "displayName"] call TFAR_fnc_getLrRadioProperty) select [0, MAX_RADIONAME_LEN],
                                 getText(configFile >> "CfgVehicles"  >> typeOf (_radio select 0) >> "picture")
                             ],
-                            _channel + 1,
+                            [_radio, _channel + 1] call TFAR_fnc_formatChannel,
                             _frequency
                         ];
 

--- a/addons/core/functions/fnc_doSRTransmit.sqf
+++ b/addons/core/functions/fnc_doSRTransmit.sqf
@@ -50,7 +50,7 @@ private _hintText = format[
                                     ([_radio, "displayName", ""] call DFUNC(getWeaponConfigProperty)) select [0, MAX_RADIONAME_LEN],
                                     ([_radio, "picture", ""] call DFUNC(getWeaponConfigProperty))
                                     ],
-                            _channel + 1,
+                            [_radio, _channel + 1] call TFAR_fnc_formatChannel,
                             _frequency
                         ];
 

--- a/addons/core/functions/fnc_doSRTransmitEnd.sqf
+++ b/addons/core/functions/fnc_doSRTransmitEnd.sqf
@@ -33,7 +33,7 @@ private _hintText = format[
                                     ([_radio, "displayName", ""] call DFUNC(getWeaponConfigProperty)) select [0, MAX_RADIONAME_LEN],
                                     ([_radio, "picture", ""] call DFUNC(getWeaponConfigProperty))
                                 ],
-                            _channel + 1,
+                            [_radio, _channel + 1] call TFAR_fnc_formatChannel,
                             _frequency
                         ];
 

--- a/addons/core/functions/fnc_formatChannel.sqf
+++ b/addons/core/functions/fnc_formatChannel.sqf
@@ -1,0 +1,34 @@
+#include "script_component.hpp"
+
+/*
+  Name: TFAR_fnc_formatChannel
+
+  Author: Darojax
+    Formats a channel number and its optional name for structured-text hints.
+
+  Arguments:
+    0: Radio <ARRAY|STRING>
+    1: 1-based channel number <NUMBER>
+
+  Return Value:
+    Channel number, optionally followed by its escaped name <STRING>
+
+  Example:
+    [(call TFAR_fnc_activeSwRadio), 1] call TFAR_fnc_formatChannel;
+
+  Public: No
+*/
+
+params [
+    ["_radio", "", [[], ""]],
+    ["_channel", 1, [0]]
+];
+
+private _channelName = [_radio, _channel] call TFAR_fnc_getChannelName;
+if (_channelName isEqualTo "") exitWith {str _channel};
+
+_channelName = [_channelName, "&", "&amp;"] call CBA_fnc_replace;
+_channelName = [_channelName, "<", "&lt;"] call CBA_fnc_replace;
+_channelName = [_channelName, ">", "&gt;"] call CBA_fnc_replace;
+
+format ["%1 - %2", _channel, _channelName]

--- a/addons/core/functions/fnc_getChannelName.sqf
+++ b/addons/core/functions/fnc_getChannelName.sqf
@@ -1,0 +1,34 @@
+#include "script_component.hpp"
+
+/*
+  Name: TFAR_fnc_getChannelName
+
+  Author: Darojax
+    Returns the name assigned to a radio channel's current frequency. Channel
+    numbers do not own names; this is a convenience wrapper around
+    TFAR_fnc_getFrequencyName.
+
+  Arguments:
+    0: Radio <ARRAY|STRING>
+    1: 1-based channel number <NUMBER>
+
+  Return Value:
+    Frequency name, or an empty string if no name is assigned <STRING>
+
+  Example:
+    [(call TFAR_fnc_activeSwRadio), 1] call TFAR_fnc_getChannelName;
+
+  Public: Yes
+*/
+
+params [
+    ["_radio", "", [[], ""]],
+    ["_channel", 1, [0]]
+];
+
+private _isLrRadio = _radio isEqualType [];
+private _maxChannels = [TFAR_MAX_CHANNELS, TFAR_MAX_LR_CHANNELS] select _isLrRadio;
+if (_channel < 1 || {_channel > _maxChannels}) exitWith {""};
+
+private _frequency = [_radio, _channel] call TFAR_fnc_getChannelFrequency;
+[_radio, _frequency] call TFAR_fnc_getFrequencyName

--- a/addons/core/functions/fnc_getFrequencyName.sqf
+++ b/addons/core/functions/fnc_getFrequencyName.sqf
@@ -1,0 +1,55 @@
+#include "script_component.hpp"
+
+/*
+  Name: TFAR_fnc_getFrequencyName
+
+  Author: Darojax
+    Returns the side-specific name assigned to a radio frequency.
+
+  Arguments:
+    0: Radio <ARRAY|STRING>
+    1: Frequency <NUMBER|STRING>
+
+  Return Value:
+    Frequency name, or an empty string if no name is assigned <STRING>
+
+  Example:
+    [(call TFAR_fnc_activeSwRadio), "111"] call TFAR_fnc_getFrequencyName;
+
+  Public: Yes
+*/
+
+params [
+    ["_radio", "", [[], ""]],
+    ["_frequency", "", [0, ""]]
+];
+
+private _frequencyString = if (_frequency isEqualType "") then {_frequency} else {str _frequency};
+if (_frequencyString isEqualTo "") exitWith {""};
+
+private _radioSide = _radio call TFAR_fnc_getRadioSide;
+if !(_radioSide in [west, east, independent]) exitWith {""};
+
+private _radioType = ["sr", "lr"] select (_radio isEqualType []);
+private _sideName = switch (_radioSide) do {
+    case west: {"west"};
+    case east: {"east"};
+    default {"independent"};
+};
+
+private _frequencyNumber = TFAR_FREQUENCYSTRING_TO_FREQNUMBER(_frequencyString);
+private _frequencyNames = missionNamespace getVariable [format ["TFAR_frequencyNames_%1_%2", _radioType, _sideName], []];
+private _definitionIndex = _frequencyNames findIf {
+    _x isEqualType [] &&
+    {count _x >= 2} &&
+    {
+        private _definedFrequency = _x param [0, "", [0, ""]];
+        private _definedFrequencyString = if (_definedFrequency isEqualType "") then {_definedFrequency} else {str _definedFrequency};
+        _definedFrequencyString isNotEqualTo "" &&
+        {TFAR_FREQUENCYSTRING_TO_FREQNUMBER(_definedFrequencyString) == _frequencyNumber}
+    }
+};
+
+if (_definitionIndex < 0) exitWith {""};
+
+((_frequencyNames select _definitionIndex) param [1, "", [""]]) select [0, TFAR_MAX_CHANNEL_NAME_LENGTH]

--- a/addons/core/functions/fnc_getRadioDialogFrequencyPosition.sqf
+++ b/addons/core/functions/fnc_getRadioDialogFrequencyPosition.sqf
@@ -1,0 +1,51 @@
+#include "script_component.hpp"
+
+/*
+  Name: TFAR_fnc_getRadioDialogFrequencyPosition
+
+  Author: Darojax
+    Returns the unmodified frequency-control position relative to the channel
+    control, allowing movable radio dialogs to retain their current location.
+
+  Arguments:
+    0: Frequency edit control <CONTROL>
+    1: Channel control IDC <NUMBER>
+
+  Return Value:
+    Frequency control position <ARRAY>
+
+  Public: No
+*/
+
+params [
+    ["_frequencyControl", controlNull, [controlNull]],
+    ["_channelControlIdc", -1, [0]]
+];
+
+if (isNull _frequencyControl) exitWith {[]};
+
+private _channelControl = (ctrlParent _frequencyControl) displayCtrl _channelControlIdc;
+if (isNull _channelControl) exitWith {ctrlPosition _frequencyControl};
+
+private _relativePosition = _frequencyControl getVariable ["TFAR_frequencyPositionRelativeToChannel", []];
+
+if (count _relativePosition != 4) then {
+    private _frequencyPosition = ctrlPosition _frequencyControl;
+    private _channelPosition = ctrlPosition _channelControl;
+
+    _relativePosition = [
+        (_frequencyPosition select 0) - (_channelPosition select 0),
+        (_frequencyPosition select 1) - (_channelPosition select 1),
+        _frequencyPosition select 2,
+        _frequencyPosition select 3
+    ];
+    _frequencyControl setVariable ["TFAR_frequencyPositionRelativeToChannel", _relativePosition];
+};
+
+private _channelPosition = ctrlPosition _channelControl;
+[
+    (_channelPosition select 0) + (_relativePosition select 0),
+    (_channelPosition select 1) + (_relativePosition select 1),
+    _relativePosition select 2,
+    _relativePosition select 3
+]

--- a/addons/core/functions/fnc_getRadioSide.sqf
+++ b/addons/core/functions/fnc_getRadioSide.sqf
@@ -1,0 +1,47 @@
+#include "script_component.hpp"
+
+/*
+  Name: TFAR_fnc_getRadioSide
+
+  Author: Darojax
+    Returns the TFAR side affiliation of an SW or LR radio. The current radio
+    code is preferred when it matches a configured side code; the radio type's
+    encryption-code property is used as the fallback.
+
+  Arguments:
+    Radio <ARRAY|STRING>
+
+  Return Value:
+    Radio side, or sideUnknown when no affiliation can be determined <SIDE>
+
+  Example:
+    (call TFAR_fnc_activeSwRadio) call TFAR_fnc_getRadioSide;
+
+  Public: Yes
+*/
+
+private _radio = _this;
+if !(_radio isEqualType [] || {_radio isEqualType ""}) exitWith {sideUnknown};
+
+private _isLrRadio = _radio isEqualType [];
+private _settings = _radio call ([TFAR_fnc_getSwSettings, TFAR_fnc_getLrSettings] select _isLrRadio);
+if (isNil "_settings") exitWith {sideUnknown};
+
+private _radioCode = _settings param [TFAR_CODE_OFFSET, "", [""]];
+if (_radioCode isEqualTo (missionNamespace getVariable ["tf_west_radio_code", "_bluefor"])) exitWith {west};
+if (_radioCode isEqualTo (missionNamespace getVariable ["tf_east_radio_code", "_opfor"])) exitWith {east};
+if (_radioCode isEqualTo (missionNamespace getVariable ["tf_independent_radio_code", "_independent"])) exitWith {independent};
+
+private _encryptionCodeProperty = if (_isLrRadio) then {
+    [_radio select 0, "tf_encryptionCode", ""] call TFAR_fnc_getLrRadioProperty
+} else {
+    [_radio, "tf_encryptionCode", ""] call TFAR_fnc_getWeaponConfigProperty
+};
+
+switch (toLower _encryptionCodeProperty) do {
+    case "tf_west_radio_code": {west};
+    case "tf_east_radio_code": {east};
+    case "tf_guer_radio_code": {independent};
+    case "tf_independent_radio_code": {independent};
+    default {sideUnknown};
+}

--- a/addons/core/functions/fnc_getSwDialogFrequencyPosition.sqf
+++ b/addons/core/functions/fnc_getSwDialogFrequencyPosition.sqf
@@ -1,0 +1,21 @@
+#include "script_component.hpp"
+
+/*
+  Name: TFAR_fnc_getSwDialogFrequencyPosition
+
+  Author: Darojax
+    Returns the unmodified frequency-control position relative to the channel
+    control, allowing movable radio dialogs to retain their current location.
+
+  Arguments:
+    0: Frequency edit control <CONTROL>
+
+  Return Value:
+    Frequency control position <ARRAY>
+
+  Public: No
+*/
+
+params [["_frequencyControl", controlNull, [controlNull]]];
+
+[_frequencyControl, SW_CHANNEL] call TFAR_fnc_getRadioDialogFrequencyPosition

--- a/addons/core/functions/fnc_initCBASettings.sqf
+++ b/addons/core/functions/fnc_initCBASettings.sqf
@@ -440,6 +440,60 @@
     }
 ] call CBA_Settings_fnc_init;
 [
+    "TFAR_setting_frequencyNames_sr_west",
+    "EDITBOX",
+    [ELSTRING(settings,FrequencyNames_SR_west), ELSTRING(settings,FrequencyNames_desc)],
+    localize ELSTRING(settings,global),
+    "",
+    1,
+    {[_this, "TFAR_frequencyNames_sr_west", false] call DFUNC(applyFrequencyNamesSetting);}
+] call CBA_Settings_fnc_init;
+[
+    "TFAR_setting_frequencyNames_sr_east",
+    "EDITBOX",
+    [ELSTRING(settings,FrequencyNames_SR_east), ELSTRING(settings,FrequencyNames_desc)],
+    localize ELSTRING(settings,global),
+    "",
+    1,
+    {[_this, "TFAR_frequencyNames_sr_east", false] call DFUNC(applyFrequencyNamesSetting);}
+] call CBA_Settings_fnc_init;
+[
+    "TFAR_setting_frequencyNames_sr_independent",
+    "EDITBOX",
+    [ELSTRING(settings,FrequencyNames_SR_independent), ELSTRING(settings,FrequencyNames_desc)],
+    localize ELSTRING(settings,global),
+    "",
+    1,
+    {[_this, "TFAR_frequencyNames_sr_independent", false] call DFUNC(applyFrequencyNamesSetting);}
+] call CBA_Settings_fnc_init;
+[
+    "TFAR_setting_frequencyNames_lr_west",
+    "EDITBOX",
+    [ELSTRING(settings,FrequencyNames_LR_west), ELSTRING(settings,FrequencyNames_desc)],
+    localize ELSTRING(settings,global),
+    "",
+    1,
+    {[_this, "TFAR_frequencyNames_lr_west", true] call DFUNC(applyFrequencyNamesSetting);}
+] call CBA_Settings_fnc_init;
+[
+    "TFAR_setting_frequencyNames_lr_east",
+    "EDITBOX",
+    [ELSTRING(settings,FrequencyNames_LR_east), ELSTRING(settings,FrequencyNames_desc)],
+    localize ELSTRING(settings,global),
+    "",
+    1,
+    {[_this, "TFAR_frequencyNames_lr_east", true] call DFUNC(applyFrequencyNamesSetting);}
+] call CBA_Settings_fnc_init;
+[
+    "TFAR_setting_frequencyNames_lr_independent",
+    "EDITBOX",
+    [ELSTRING(settings,FrequencyNames_LR_independent), ELSTRING(settings,FrequencyNames_desc)],
+    localize ELSTRING(settings,global),
+    "",
+    1,
+    {[_this, "TFAR_frequencyNames_lr_independent", true] call DFUNC(applyFrequencyNamesSetting);}
+] call CBA_Settings_fnc_init;
+[
     "TFAR_giveMicroDagrToSoldier",
     "CHECKBOX",
     ELSTRING(settings,give_microdagr_to_soldier),

--- a/addons/core/functions/fnc_parseFrequencyNamesInput.sqf
+++ b/addons/core/functions/fnc_parseFrequencyNamesInput.sqf
@@ -1,0 +1,71 @@
+#include "script_component.hpp"
+
+/*
+  Name: TFAR_fnc_parseFrequencyNamesInput
+
+  Author: Darojax
+    Parses a comma-separated list of frequency=name definitions.
+
+  Arguments:
+    0: Frequency-name definitions <STRING>
+    1: Is long-range frequency list <BOOL>
+
+  Return Value:
+    Valid frequency-name definitions, limited to 16 entries <ARRAY>
+
+  Example:
+    ["111=COY NET,222=1/2 SEC", false] call TFAR_fnc_parseFrequencyNamesInput;
+
+  Public: Yes
+*/
+
+params [
+    ["_input", "", [""]],
+    ["_isLrRadio", false, [false]]
+];
+
+private _trimString = {
+    private _characters = toArray _this;
+    while {count _characters > 0 && {(_characters select 0) <= 32}} do {
+        _characters deleteAt 0;
+    };
+    while {count _characters > 0 && {(_characters select (count _characters - 1)) <= 32}} do {
+        _characters deleteAt (count _characters - 1);
+    };
+    toString _characters
+};
+
+private _minimumFrequency = [TFAR_MIN_SW_FREQ, TFAR_MIN_ASIP_FREQ] select _isLrRadio;
+private _maximumFrequency = [TFAR_MAX_SW_FREQ, TFAR_MAX_ASIP_FREQ] select _isLrRadio;
+private _definitions = [];
+
+{
+    private _separatorIndex = _x find "=";
+    if (_separatorIndex > 0) then {
+        private _frequencyString = (_x select [0, _separatorIndex]) call _trimString;
+        private _name = (_x select [_separatorIndex + 1]) call _trimString;
+        private _frequency = TFAR_FREQUENCYSTRING_TO_FREQNUMBER(_frequencyString);
+
+        if (
+            _frequencyString isNotEqualTo "" &&
+            {_name isNotEqualTo ""} &&
+            {_frequency >= _minimumFrequency} &&
+            {_frequency <= _maximumFrequency}
+        ) then {
+            _name = _name select [0, TFAR_MAX_CHANNEL_NAME_LENGTH];
+            private _definitionIndex = _definitions findIf {
+                TFAR_FREQUENCYSTRING_TO_FREQNUMBER(_x select 0) == _frequency
+            };
+
+            if (_definitionIndex >= 0) then {
+                _definitions set [_definitionIndex, [_frequencyString, _name]];
+            } else {
+                if (count _definitions < TFAR_MAX_FREQUENCY_NAMES) then {
+                    _definitions pushBack [_frequencyString, _name];
+                };
+            };
+        };
+    };
+} forEach (_input splitString ",");
+
+_definitions

--- a/addons/core/functions/fnc_setFrequencyName.sqf
+++ b/addons/core/functions/fnc_setFrequencyName.sqf
@@ -1,0 +1,82 @@
+#include "script_component.hpp"
+
+/*
+  Name: TFAR_fnc_setFrequencyName
+
+  Author: Darojax
+    Assigns a side-specific name to an SR or LR frequency. This server-side
+    mission configuration is broadcast to clients. Names are truncated to the
+    supported display length. Pass an empty name to remove the definition.
+
+  Arguments:
+    0: Radio side <SIDE>
+    1: Is long-range frequency <BOOL>
+    2: Frequency <NUMBER|STRING>
+    3: Frequency name <STRING>
+
+  Return Value:
+    Whether the frequency-name definition was set and broadcast <BOOL>
+
+  Example:
+    [west, false, "111", "COY NET"] call TFAR_fnc_setFrequencyName;
+
+  Public: Yes
+*/
+
+params [
+    ["_side", sideUnknown, [sideUnknown]],
+    ["_isLrRadio", false, [false]],
+    ["_frequency", "", [0, ""]],
+    ["_name", "", [""]]
+];
+
+if (!isServer || {!(_side in [west, east, independent])}) exitWith {false};
+
+private _frequencyString = if (_frequency isEqualType "") then {_frequency} else {str _frequency};
+if (_frequencyString isEqualTo "") exitWith {false};
+
+_name = _name select [0, TFAR_MAX_CHANNEL_NAME_LENGTH];
+
+private _radioType = ["sr", "lr"] select _isLrRadio;
+private _sideName = switch (_side) do {
+    case west: {"west"};
+    case east: {"east"};
+    default {"independent"};
+};
+private _variableName = format ["TFAR_frequencyNames_%1_%2", _radioType, _sideName];
+private _frequencyNumber = TFAR_FREQUENCYSTRING_TO_FREQNUMBER(_frequencyString);
+private _frequencyNames = +(missionNamespace getVariable [_variableName, []]);
+private _definitionIndex = _frequencyNames findIf {
+    _x isEqualType [] &&
+    {count _x >= 2} &&
+    {
+        private _definedFrequency = _x param [0, "", [0, ""]];
+        private _definedFrequencyString = if (_definedFrequency isEqualType "") then {_definedFrequency} else {str _definedFrequency};
+        _definedFrequencyString isNotEqualTo "" &&
+        {TFAR_FREQUENCYSTRING_TO_FREQNUMBER(_definedFrequencyString) == _frequencyNumber}
+    }
+};
+
+private _oldName = "";
+if (_definitionIndex >= 0) then {
+    _oldName = (_frequencyNames select _definitionIndex) param [1, "", [""]];
+};
+
+if (_name isNotEqualTo "" && {_definitionIndex < 0} && {count _frequencyNames >= TFAR_MAX_FREQUENCY_NAMES}) exitWith {false};
+
+if (_name isEqualTo "") then {
+    if (_definitionIndex >= 0) then {
+        _frequencyNames deleteAt _definitionIndex;
+    };
+} else {
+    if (_definitionIndex >= 0) then {
+        _frequencyNames set [_definitionIndex, [_frequencyString, _name]];
+    } else {
+        _frequencyNames pushBack [_frequencyString, _name];
+    };
+};
+
+missionNamespace setVariable [_variableName, _frequencyNames, true];
+["OnFrequencyNameChanged", [_side, _isLrRadio, _frequencyString, _oldName, _name]] call TFAR_fnc_fireEventHandlers;
+
+true

--- a/addons/core/functions/fnc_showRadioDialogFrequency.sqf
+++ b/addons/core/functions/fnc_showRadioDialogFrequency.sqf
@@ -1,0 +1,38 @@
+#include "script_component.hpp"
+
+/*
+  Name: TFAR_fnc_showRadioDialogFrequency
+
+  Author: Darojax
+    Replaces a displayed channel name with its editable frequency when the
+    player clicks the frequency field.
+
+  Arguments:
+    0: Frequency edit control <CONTROL>
+    1: Radio <ARRAY|STRING>
+    2: Long-range radio <BOOL>
+    3: Channel control IDC <NUMBER>
+
+  Return Value:
+    None
+
+  Public: No
+*/
+
+params [
+    ["_frequencyControl", controlNull, [controlNull]],
+    ["_radio", "", [[], ""]],
+    ["_isLrRadio", false, [false]],
+    ["_channelControlIdc", -1, [0]]
+];
+
+if (isNull _frequencyControl) exitWith {};
+
+private _channel = _radio call ([TFAR_fnc_getSwChannel, TFAR_fnc_getLrChannel] select _isLrRadio);
+private _channelName = [_radio, _channel + 1] call TFAR_fnc_getChannelName;
+
+if (_channelName isEqualTo "" || {ctrlText _frequencyControl isNotEqualTo _channelName}) exitWith {};
+
+_frequencyControl ctrlSetPosition ([_frequencyControl, _channelControlIdc] call TFAR_fnc_getRadioDialogFrequencyPosition);
+_frequencyControl ctrlCommit 0;
+_frequencyControl ctrlSetText (_radio call ([TFAR_fnc_getSwFrequency, TFAR_fnc_getLrFrequency] select _isLrRadio));

--- a/addons/core/functions/fnc_updateRadioDialogFrequency.sqf
+++ b/addons/core/functions/fnc_updateRadioDialogFrequency.sqf
@@ -1,0 +1,63 @@
+#include "script_component.hpp"
+
+/*
+  Name: TFAR_fnc_updateRadioDialogFrequency
+
+  Author: Darojax
+    Updates a radio dialog's frequency field with either the frequency or its
+    assigned name, preserving the radio's original layout when unnamed.
+
+  Arguments:
+    0: Frequency <STRING>
+    1: Channel name <STRING>
+    2: Show channel name <BOOL>
+    3: Dialog IDD <NUMBER>
+    4: Name expansion to the left, in pixels <NUMBER>
+    5: Frequency edit control IDC <NUMBER>
+    6: Channel control IDC <NUMBER>
+
+  Return Value:
+    None
+
+  Public: No
+*/
+
+params [
+    ["_frequency", "", [""]],
+    ["_channelName", "", [""]],
+    ["_showChannelName", false, [false]],
+    ["_dialogIdd", -1, [0]],
+    ["_offsetPixels", 0, [0]],
+    ["_frequencyControlIdc", -1, [0]],
+    ["_channelControlIdc", -1, [0]]
+];
+
+ctrlSetText [_frequencyControlIdc, [_frequency, _channelName] select _showChannelName];
+
+if (_dialogIdd < 0) exitWith {};
+
+disableSerialization;
+private _frequencyControl = (findDisplay _dialogIdd) displayCtrl _frequencyControlIdc;
+if (isNull _frequencyControl) exitWith {};
+
+private _displayPosition = [_frequencyControl, _channelControlIdc] call TFAR_fnc_getRadioDialogFrequencyPosition;
+
+if (_showChannelName) then {
+    private _offset = _offsetPixels * pixelW;
+    private _displayLeft = (_displayPosition select 0) - _offset;
+    private _displayRight = (_displayPosition select 0) + (_displayPosition select 2);
+    private _displayWidth = _displayRight - _displayLeft;
+    private _textWidth = ctrlTextWidth _frequencyControl;
+
+    _displayPosition set [0, _displayLeft];
+    _displayPosition set [2, _displayWidth];
+
+    if (_textWidth > 0 && {_textWidth < _displayWidth}) then {
+        private _textLeft = _displayLeft + ((_displayWidth - _textWidth) / 2);
+        _displayPosition set [0, _textLeft];
+        _displayPosition set [2, _displayRight - _textLeft];
+    };
+};
+
+_frequencyControl ctrlSetPosition _displayPosition;
+_frequencyControl ctrlCommit 0;

--- a/addons/core/functions/hint/fnc_showRadioInfo.sqf
+++ b/addons/core/functions/hint/fnc_showRadioInfo.sqf
@@ -27,7 +27,9 @@ params ["_radio", "_isLrRadio"];
 private _name = if(_isLrRadio) then {[typeOf (_radio select 0), "displayName", ""] call DFUNC(getVehicleConfigProperty)} else {[_radio, "displayName", ""] call DFUNC(getWeaponConfigProperty)};
 private _picture = if(_isLrRadio) then {[typeOf (_radio select 0), "picture", ""] call DFUNC(getVehicleConfigProperty)} else {[_radio, "picture", ""] call DFUNC(getWeaponConfigProperty)};
 
-private _channel = if(_isLrRadio) then {format[localize LSTRING(active_lr_channel), (_radio call TFAR_fnc_getLrChannel) + 1]} else {format[localize LSTRING(active_sw_channel), (_radio call TFAR_fnc_getSwChannel) + 1]};
+private _channelIndex = if (_isLrRadio) then {_radio call TFAR_fnc_getLrChannel} else {_radio call TFAR_fnc_getSwChannel};
+private _channelDisplay = [_radio, _channelIndex + 1] call TFAR_fnc_formatChannel;
+private _channel = if (_isLrRadio) then {format [localize LSTRING(active_lr_channel), _channelDisplay]} else {format [localize LSTRING(active_sw_channel), _channelDisplay]};
 private _additional = nil;
 if (_isLrRadio) then {
     _additional = _radio call TFAR_fnc_getAdditionalLrChannel;
@@ -36,7 +38,8 @@ if (_isLrRadio) then {
 };
 private _add_channel = "";
 if (_additional > -1) then {
-    _add_channel = if(_isLrRadio) then {format[localize LSTRING(active_additional_lr_channel), (_radio call TFAR_fnc_getAdditionalLrChannel) + 1]} else {format[localize LSTRING(active_additional_sw_channel), (_radio call TFAR_fnc_getAdditionalSwChannel) + 1]};
+    private _additionalDisplay = [_radio, _additional + 1] call TFAR_fnc_formatChannel;
+    _add_channel = if (_isLrRadio) then {format [localize LSTRING(active_additional_lr_channel), _additionalDisplay]} else {format [localize LSTRING(active_additional_sw_channel), _additionalDisplay]};
 };
 
 private _imagesize = "1.6";

--- a/addons/core/stringtable.xml
+++ b/addons/core/stringtable.xml
@@ -298,6 +298,34 @@
                 <Italian>Volume radio predefinito</Italian>
                 <Czech>Výchozí hlasitost rádia</Czech>
             </Key>
+            <Key ID="STR_TFAR_SETTINGS_FrequencyNames_SR_west">
+                <Original>SR frequency names (WEST)</Original>
+                <English>SR frequency names (WEST)</English>
+            </Key>
+            <Key ID="STR_TFAR_SETTINGS_FrequencyNames_SR_east">
+                <Original>SR frequency names (EAST)</Original>
+                <English>SR frequency names (EAST)</English>
+            </Key>
+            <Key ID="STR_TFAR_SETTINGS_FrequencyNames_SR_independent">
+                <Original>SR frequency names (Independent)</Original>
+                <English>SR frequency names (Independent)</English>
+            </Key>
+            <Key ID="STR_TFAR_SETTINGS_FrequencyNames_LR_west">
+                <Original>LR frequency names (WEST)</Original>
+                <English>LR frequency names (WEST)</English>
+            </Key>
+            <Key ID="STR_TFAR_SETTINGS_FrequencyNames_LR_east">
+                <Original>LR frequency names (EAST)</Original>
+                <English>LR frequency names (EAST)</English>
+            </Key>
+            <Key ID="STR_TFAR_SETTINGS_FrequencyNames_LR_independent">
+                <Original>LR frequency names (Independent)</Original>
+                <English>LR frequency names (Independent)</English>
+            </Key>
+            <Key ID="STR_TFAR_SETTINGS_FrequencyNames_desc">
+                <Original>Comma-separated frequency=name pairs. Up to 16 definitions; displayed names are limited to 8 characters. Example: 111=COY NET,222=1/2 SEC</Original>
+                <English>Comma-separated frequency=name pairs. Up to 16 definitions; displayed names are limited to 8 characters. Example: 111=COY NET,222=1/2 SEC</English>
+            </Key>
             <Key ID="STR_TFAR_SETTINGS_same_lr_frequencies_for_side">
                 <Original>Same LR frequencies for side</Original>
                 <English>Same LR frequencies for side</English>

--- a/addons/handhelds/anprc148jem/CfgWeapons.hpp
+++ b/addons/handhelds/anprc148jem/CfgWeapons.hpp
@@ -11,6 +11,9 @@ class TFAR_anprc148jem: ItemRadio {
     tf_dialog = "anprc148jem_radio_dialog";
     tf_encryptionCode = "tf_independent_radio_code";
     tf_dialogUpdate = "call TFAR_fnc_updateSWDialogToChannel;";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 6000;
+    tf_channelNameOffset = 44;
     tf_subtype = "digital";
     tf_parent = "TFAR_anprc148jem";
     tf_additional_channel = 1;

--- a/addons/handhelds/anprc148jem/ui/anprc148jem.hpp
+++ b/addons/handhelds/anprc148jem/ui/anprc148jem.hpp
@@ -65,10 +65,7 @@ class anprc148jem_radio_dialog {
         w = 0.0249375 * safezoneW;
         h = 0.0280062 * safezoneH;
         tooltip = ECSTRING(core,clear_frequency);
-        action = QUOTE( \
-            ctrlSetText [ARR_2(IDC_ANPRC148JEM_EDIT, '')]; \
-            ctrlSetFocus ((findDisplay IDD_ANPRC148JEM_RADIO_DIALOG) displayCtrl IDC_ANPRC148JEM_EDIT); \
-        );
+        TFAR_CHANNEL_NAME_CLEAR_ACTION(IDD_ANPRC148JEM_RADIO_DIALOG,IDC_ANPRC148JEM_EDIT,SW_CHANNEL);
     };
     class edit: RscEditLCD {
         idc = IDC_ANPRC148JEM_EDIT;
@@ -81,6 +78,7 @@ class anprc148jem_radio_dialog {
         tooltip = ECSTRING(core,current_freq);
         canModify = 1;
         moving = 1;
+        TFAR_CHANNEL_NAME_EDIT_HANDLER(TF_sw_dialog_radio,SW_CHANNEL);
         onKeyUp = QUOTE( \
             if (_this select 1 in [ARR_2(28,156)]) then { \
                 [((ctrlParent (_this select 0))) displayCtrl IDC_ANPRC148JEM_EDIT] call TFAR_handhelds_fnc_onButtonClick_Enter; \

--- a/addons/handhelds/anprc152/CfgWeapons.hpp
+++ b/addons/handhelds/anprc152/CfgWeapons.hpp
@@ -11,6 +11,9 @@ class TFAR_anprc152: ItemRadio {
     tf_dialog = "anprc152_radio_dialog";
     tf_encryptionCode = "tf_west_radio_code";
     tf_dialogUpdate = "call TFAR_fnc_updateSWDialogToChannel;";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 1333;
+    tf_channelNameOffset = 44;
     tf_subtype = "digital";
     tf_parent = "TFAR_anprc152";
     tf_additional_channel = 1;

--- a/addons/handhelds/anprc152/ui/anprc152.hpp
+++ b/addons/handhelds/anprc152/ui/anprc152.hpp
@@ -57,6 +57,7 @@ class anprc152_radio_dialog {
         shadow = 2;
         tooltip = ECSTRING(core,current_freq);
         canModify = 1;
+        TFAR_CHANNEL_NAME_EDIT_HANDLER(TF_sw_dialog_radio,SW_CHANNEL);
         onKeyUp = QUOTE( \
             if (_this select 1 in [ARR_2(28,156)]) then { \
                 [((ctrlParent (_this select 0))) displayCtrl IDC_ANPRC152_EDIT] call TFAR_handhelds_fnc_onButtonClick_Enter; \
@@ -92,10 +93,7 @@ class anprc152_radio_dialog {
         w = 0.0146438 * safezoneW;
         h = 0.0198 * safezoneH;
         tooltip = ECSTRING(core,clear_frequency);
-        action = QUOTE( \
-            ctrlSetText [ARR_2(IDC_ANPRC152_EDIT, '')]; \
-            ctrlSetFocus ((findDisplay IDD_ANPRC152_RADIO_DIALOG) displayCtrl IDC_ANPRC152_EDIT); \
-        );
+        TFAR_CHANNEL_NAME_CLEAR_ACTION(IDD_ANPRC152_RADIO_DIALOG,IDC_ANPRC152_EDIT,SW_CHANNEL);
     };
     class additional: HiddenButton {
         idc = IDC_ANPRC152_RADIO_DIALOG_ADDITIONAL;

--- a/addons/handhelds/anprc154/CfgWeapons.hpp
+++ b/addons/handhelds/anprc154/CfgWeapons.hpp
@@ -11,6 +11,9 @@ class TFAR_anprc154: ItemRadio {
     tf_dialog = "anprc154_radio_dialog";
     tf_encryptionCode = "tf_independent_radio_code";
     tf_dialogUpdate = "call TFAR_fnc_updateSWDialogToChannel;";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 3198;
+    tf_channelNameOffset = 44;
     tf_subtype = "digital";
     tf_parent = "TFAR_anprc154";
     tf_additional_channel = 0;

--- a/addons/handhelds/anprc154/ui/anprc154.hpp
+++ b/addons/handhelds/anprc154/ui/anprc154.hpp
@@ -164,6 +164,7 @@ class anprc154_radio_dialog {
         shadow = 2;
         canModify = 1;
         tooltip = ECSTRING(core,current_freq);
+        TFAR_CHANNEL_NAME_EDIT_HANDLER(TF_sw_dialog_radio,SW_CHANNEL);
         onKeyUp = QUOTE( \
             if (_this select 1 in [ARR_2(28,156)]) then { \
                 [((ctrlParent (_this select 0))) displayCtrl IDC_MICRODAGR_EDIT] call TFAR_handhelds_fnc_onButtonClick_Enter; \
@@ -180,10 +181,7 @@ class anprc154_radio_dialog {
         tooltip = ECSTRING(core,clear_frequency);
         font = "TFAR_font_dots";
         shadow = 2;
-        action = QUOTE( \
-            ctrlSetText [ARR_2(IDC_MICRODAGR_EDIT, '')]; \
-            ctrlSetFocus ((findDisplay IDD_ANPRC152_RADIO_DIALOG) displayCtrl IDC_MICRODAGR_EDIT); \
-        );
+        TFAR_CHANNEL_NAME_CLEAR_ACTION(IDD_ANPRC154_RADIO_DIALOG,IDC_MICRODAGR_EDIT,SW_CHANNEL);
     };
     class enter: HiddenButton {
         idc = IDC_MICRODAGR_ENTER;

--- a/addons/handhelds/pnr1000a/CfgWeapons.hpp
+++ b/addons/handhelds/pnr1000a/CfgWeapons.hpp
@@ -13,6 +13,9 @@ class TFAR_pnr1000a: ItemRadio {
     tf_parent = "TFAR_pnr1000a";
     tf_additional_channel = 0;
     tf_dialogUpdate = "call TFAR_fnc_updateSWDialogToChannel;";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 3083;
+    tf_channelNameOffset = 44;
 };
 HIDDEN_CLASS(tf_pnr1000a : TFAR_pnr1000a); //#Deprecated dummy class for backwards compat
 TF_RADIO_IDS(TFAR_pnr1000a,PNR-1000A)

--- a/addons/handhelds/pnr1000a/ui/pnr1000a.hpp
+++ b/addons/handhelds/pnr1000a/ui/pnr1000a.hpp
@@ -154,6 +154,7 @@ class pnr1000a_radio_dialog {
         shadow = 2;
         canModify = 1;
         tooltip = ECSTRING(core,current_freq);
+        TFAR_CHANNEL_NAME_EDIT_HANDLER(TF_sw_dialog_radio,SW_CHANNEL);
         onKeyUp = QUOTE( \
             if (_this select 1 in [ARR_2(28,156)]) then { \
                 [((ctrlParent (_this select 0))) displayCtrl IDC_MICRODAGR_EDIT] call TFAR_handhelds_fnc_onButtonClick_Enter; \
@@ -170,10 +171,7 @@ class pnr1000a_radio_dialog {
         tooltip = ECSTRING(core,clear_frequency);
         font = "TFAR_font_dots";
         shadow = 2;
-        action = QUOTE( \
-            ctrlSetText [ARR_2(IDC_MICRODAGR_EDIT, '')]; \
-            ctrlSetFocus ((findDisplay IDC_PNR1000A_RADIO_DIALOG) displayCtrl IDC_MICRODAGR_EDIT); \
-        );
+        TFAR_CHANNEL_NAME_CLEAR_ACTION(IDC_PNR1000A_RADIO_DIALOG,IDC_MICRODAGR_EDIT,SW_CHANNEL);
     };
     class enter: HiddenButton {
         idc = IDC_MICRODAGR_ENTER;

--- a/addons/handhelds/rf7800/CfgWeapons.hpp
+++ b/addons/handhelds/rf7800/CfgWeapons.hpp
@@ -14,6 +14,9 @@ class TFAR_rf7800str: ItemRadio {
     tf_parent = "TFAR_rf7800str";
     tf_additional_channel = 0;
     tf_dialogUpdate = "call TFAR_fnc_updateSWDialogToChannel;";
+    tf_showChannelName = 1;
+    tf_channelNameDialogIdd = 4425;
+    tf_channelNameOffset = 44;
 };
 HIDDEN_CLASS(tf_rf7800str : TFAR_rf7800str); //#Deprecated dummy class for backwards compat
 TF_RADIO_IDS(TFAR_rf7800str,RF-7800S-TR)

--- a/addons/handhelds/rf7800/ui/rf7800str.hpp
+++ b/addons/handhelds/rf7800/ui/rf7800str.hpp
@@ -143,6 +143,7 @@ class rf7800str_radio_dialog {
         shadow = 2;
         canModify = 1;
         tooltip = ECSTRING(core,current_freq);
+        TFAR_CHANNEL_NAME_EDIT_HANDLER(TF_sw_dialog_radio,SW_CHANNEL);
         onKeyUp = QUOTE( \
             if (_this select 1 in [ARR_2(28,156)]) then { \
                 [((ctrlParent (_this select 0))) displayCtrl IDC_MICRODAGR_EDIT] call TFAR_handhelds_fnc_onButtonClick_Enter; \
@@ -159,10 +160,7 @@ class rf7800str_radio_dialog {
         tooltip = ECSTRING(core,clear_frequency);
         font = "TFAR_font_dots";
         shadow = 2;
-        action = QUOTE( \
-            ctrlSetText [ARR_2(IDC_MICRODAGR_EDIT, '')]; \
-            ctrlSetFocus ((findDisplay IDD_RF7800STR_RADIO_DIALOG) displayCtrl IDC_MICRODAGR_EDIT); \
-        );
+        TFAR_CHANNEL_NAME_CLEAR_ACTION(IDD_RF7800STR_RADIO_DIALOG,IDC_MICRODAGR_EDIT,SW_CHANNEL);
     };
     class enter: HiddenButton {
         idc = IDC_MICRODAGR_ENTER;

--- a/addons/handhelds/uiDefines.hpp
+++ b/addons/handhelds/uiDefines.hpp
@@ -1,6 +1,11 @@
 #include "\z\tfar\addons\core\defines.hpp"
 
 #define TF_IDD_BACKGROUND 67676
+
+#define TFAR_CHANNEL_NAME_EDIT_HANDLER(RADIO,CHANNEL_IDC) \
+    onMouseButtonDown = QUOTE([ARR_4(_this select 0,RADIO,false,CHANNEL_IDC)] call TFAR_fnc_showRadioDialogFrequency;)
+#define TFAR_CHANNEL_NAME_CLEAR_ACTION(DISPLAY_IDD,EDIT_IDC,CHANNEL_IDC) \
+    action = QUOTE([ARR_2((findDisplay DISPLAY_IDD) displayCtrl EDIT_IDC,CHANNEL_IDC)] call TFAR_fnc_clearRadioDialogFrequency;)
 //--- anprc152_radio_dialog
 #define IDD_ANPRC152_RADIO_DIALOG  1333
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add side-specific names for SR and LR frequencies, configurable through six CBA settings using `frequency=name` pairs.
- Resolve names from the radio's TFAR affiliation and current frequency, independently of channel number, inventory owner, or transfer history.
- Display configured names in compatible radio dialogs, radio-information hints, and transmit notifications while preserving normal frequency entry and unnamed-radio layouts.
- Limit each SR/LR side table to 16 definitions and truncate displayed names to the supported eight-character radio display width.
- Add public functions for querying radio affiliation and frequency/channel names, plus a server-side function for changing frequency names at runtime.
- Close #1157 .

<img width="554" height="278" alt="image" src="https://github.com/user-attachments/assets/079e674f-e95f-4a79-8a25-c299a1bc8903" />

## Configuration

Example mission `cba_settings.sqf` entry:

```sqf
force force TFAR_setting_frequencyNames_sr_west = "111=COY NET,222=1/2 SEC";
```

SR and LR names are configured independently for WEST, EAST, and Independent. The feature names frequencies only; existing TFAR frequency generation, radio pickup, ownership, and transfer behavior remains unchanged.

Radios with compatible text displays are supported.

## Validation

- TFAR config validator: 0 errors.
- TFAR SQF validator: 0 errors.
- Edited core stringtable: validator passed.
- Tested in the editor and on a dedicated multiplayer server with a joining client.
- Verified SR/LR side affiliation, named and unnamed frequency switching, manual frequency entry, movable radio dialogs, hints, and radio transfer/pickup scenarios.
- Final dedicated-server and client RPTs contained no SQF, parameter, undefined-variable, or named-channel errors.
